### PR TITLE
Unique stable name reimpl

### DIFF
--- a/clang/docs/LanguageExtensions.rst
+++ b/clang/docs/LanguageExtensions.rst
@@ -2335,7 +2335,8 @@ mangling scheme at runtime. The mangler marks all the lambdas required to name
 the SYCL kernel and emits ``10000`` plus the aforementioned stable local
 ordering number of the respective lambdas. The resulting pattern is demanglable.
 Here ``10000`` is to serve as an obvious visual differentiator from ordinary
-lambdas; not emitted when non-lambda types are passed to the builtin.
+lambdas. When non-lambda types are passed to the builtin, the mangler emits
+their usual pattern without any special treatment.
 
 **Syntax**:
 

--- a/clang/docs/LanguageExtensions.rst
+++ b/clang/docs/LanguageExtensions.rst
@@ -2332,10 +2332,11 @@ it in an instantiation which changes its value.
 In order to produce the unique name, the current implementation of the bultin
 uses Itanium mangling even if the host compilation uses a different name
 mangling scheme at runtime. The mangler marks all the lambdas required to name
-the SYCL kernel and emits ``10000`` plus the aforementioned stable local
-ordering number of the respective lambdas. The resulting pattern is demanglable.
-Here ``10000`` is to serve as an obvious visual differentiator from ordinary
-lambdas. When non-lambda types are passed to the builtin, the mangler emits
+the SYCL kernel and emits a stable local ordering of the respective lambdas,
+starting from ``10000``. The initial value of ``10000`` serves as an obvious
+differentiator from ordinary lambda mangling numbers but does not serve any
+other purpose and may change in the future. The resulting pattern is
+demanglable. When non-lambda types are passed to the builtin, the mangler emits
 their usual pattern without any special treatment.
 
 **Syntax**:

--- a/clang/docs/LanguageExtensions.rst
+++ b/clang/docs/LanguageExtensions.rst
@@ -1766,7 +1766,7 @@ correctly in any circumstances. It can be used if:
   metaprogramming algorithms to be able to specify/detect types generically.
 
 - the generated kernel binary does not contain indirect calls because they
-  are eliminated using compiler optimizations e.g. devirtualization.
+  are eliminated using compiler optimizations e.g. devirtualization. 
 
 - the selected target supports the function pointer like functionality e.g.
   most CPU targets.
@@ -2312,11 +2312,11 @@ argument.
   __builtin_preserve_access_index(v->j);
 
 ``__builtin_unique_stable_name``
-------------------------
+--------------------------------
 
-``__builtin_unique_stable_name()`` is a builtin that takes a type or expression and
-produces a string literal containing a unique name for the type (or type of the
-expression) that is stable across split compilations.
+``__builtin_unique_stable_name()`` is a builtin that takes a type or unevaluated
+expression and produces a string literal containing a unique name for the type
+(or type of the expression) that is stable across split compilations.
 
 In cases where the split compilation needs to share a unique token for a type
 across the boundary (such as in an offloading situation), this name can be used
@@ -2529,7 +2529,7 @@ Guaranteed inlined copy
 ``__builtin_memcpy_inline`` has been designed as a building block for efficient
 ``memcpy`` implementations. It is identical to ``__builtin_memcpy`` but also
 guarantees not to call any external functions. See LLVM IR `llvm.memcpy.inline
-<https://llvm.org/docs/LangRef.html#llvm-memcpy-inline-intrinsic>`_ intrinsic
+<https://llvm.org/docs/LangRef.html#llvm-memcpy-inline-intrinsic>`_ intrinsic 
 for more information.
 
 This is useful to implement a custom version of ``memcpy``, implement a

--- a/clang/docs/LanguageExtensions.rst
+++ b/clang/docs/LanguageExtensions.rst
@@ -1766,7 +1766,7 @@ correctly in any circumstances. It can be used if:
   metaprogramming algorithms to be able to specify/detect types generically.
 
 - the generated kernel binary does not contain indirect calls because they
-  are eliminated using compiler optimizations e.g. devirtualization. 
+  are eliminated using compiler optimizations e.g. devirtualization.
 
 - the selected target supports the function pointer like functionality e.g.
   most CPU targets.
@@ -2311,6 +2311,30 @@ argument.
   int *pb =__builtin_preserve_access_index(&v->c[3].b);
   __builtin_preserve_access_index(v->j);
 
+``__builtin_unique_stable_name``
+------------------------
+
+``__builtin_unique_stable_name()`` is a builtin that takes a type or expression and
+produces a string literal containing a unique name for the type (or type of the
+expression) that is stable across split compilations.
+
+In cases where the split compilation needs to share a unique token for a type
+across the boundary (such as in an offloading situation), this name can be used
+for lookup purposes.
+
+This builtin is superior to RTTI for this purpose for two reasons.  First, this
+value is computed entirely at compile time, so it can be used in constant
+expressions. Second, this value encodes lambda functions based on line-number
+rather than the order in which it appears in a function. This is valuable
+because it is stable in cases where an unrelated lambda is introduced
+conditionally in the same function.
+
+The current implementation of this builtin uses a slightly modified Itanium
+Mangler to produce the unique name. The lambda ordinal is replaced with one or
+more line/column pairs in the format ``LINE->COL``, separated with a ``~``
+character. Typically, only one pair will be included, however in the case of
+macro expansions the entire macro expansion stack is expressed.
+
 Multiprecision Arithmetic Builtins
 ----------------------------------
 
@@ -2505,7 +2529,7 @@ Guaranteed inlined copy
 ``__builtin_memcpy_inline`` has been designed as a building block for efficient
 ``memcpy`` implementations. It is identical to ``__builtin_memcpy`` but also
 guarantees not to call any external functions. See LLVM IR `llvm.memcpy.inline
-<https://llvm.org/docs/LangRef.html#llvm-memcpy-inline-intrinsic>`_ intrinsic 
+<https://llvm.org/docs/LangRef.html#llvm-memcpy-inline-intrinsic>`_ intrinsic
 for more information.
 
 This is useful to implement a custom version of ``memcpy``, implement a

--- a/clang/docs/LanguageExtensions.rst
+++ b/clang/docs/LanguageExtensions.rst
@@ -2316,24 +2316,29 @@ argument.
 
 ``__builtin_unique_stable_name()`` is a builtin that takes a type or unevaluated
 expression and produces a string literal containing a unique name for the type
-(or type of the expression) that is stable across split compilations.
+(or type of the expression) that is stable across split compilations, mainly to
+support SYCL/Data Parallel C++ language.
 
 In cases where the split compilation needs to share a unique token for a type
 across the boundary (such as in an offloading situation), this name can be used
-for lookup purposes.
+for lookup purposes, such as in the SYCL Integration Header.
 
-This builtin is superior to RTTI for this purpose for two reasons.  First, this
-value is computed entirely at compile time, so it can be used in constant
-expressions. Second, this value encodes lambda functions based on line-number
-rather than the order in which it appears in a function. This is valuable
-because it is stable in cases where an unrelated lambda is introduced
-conditionally in the same function.
+The value of this builtin is computed entirely at compile time, so it can be
+used in constant expressions. This value encodes lambda functions based on a
+stable numbering order in which they appears their local declaration contexts.
+If numbering varies across the host and device sides, the device local ordering
+is picked for naming/mangling.
 
-The current implementation of this builtin uses a slightly modified Itanium
-Mangler to produce the unique name. The lambda ordinal is replaced with one or
-more line/column pairs in the format ``LINE->COL``, separated with a ``~``
-character. Typically, only one pair will be included, however in the case of
-macro expansions the entire macro expansion stack is expressed.
+In order to produce the unique name, the current implementation of the bultin
+uses ItaniumMangler to mark all the lambdas required to name the SYCL kernel
+and emits ``10000`` plus the aforementioned stable local
+ordering number of the respective lambdas. The resulting pattern is demanglable.
+
+**Syntax**:
+
+.. code-block:: c
+
+  const char* __builtin_unique_stable_name(type arg)
 
 Multiprecision Arithmetic Builtins
 ----------------------------------

--- a/clang/docs/LanguageExtensions.rst
+++ b/clang/docs/LanguageExtensions.rst
@@ -2325,20 +2325,27 @@ for lookup purposes, such as in the SYCL Integration Header.
 
 The value of this builtin is computed entirely at compile time, so it can be
 used in constant expressions. This value encodes lambda functions based on a
-stable numbering order in which they appears their local declaration contexts.
-If numbering varies across the host and device sides, the device local ordering
-is picked for naming/mangling.
+stable numbering order in which they appear in their local declaration contexts.
+Once this builtin is evaluated in a constexpr context, it is erroneous to use
+it in an instantiation which changes its value.
 
 In order to produce the unique name, the current implementation of the bultin
-uses ItaniumMangler to mark all the lambdas required to name the SYCL kernel
-and emits ``10000`` plus the aforementioned stable local
+uses Itanium mangling even if the host compilation may use a different name
+mangling scheme at runtime. The mangler mark all the lambdas required to name
+the SYCL kernel and emits ``10000`` plus the aforementioned stable local
 ordering number of the respective lambdas. The resulting pattern is demanglable.
+Here ``10000`` is to serve as an obvious visual differentiator from ordinary
+lambdas; not emitted when non-lambda types are passed to the builtin.
 
 **Syntax**:
 
 .. code-block:: c
 
-  const char* __builtin_unique_stable_name(type arg)
+  // Computes a unique stable name for the given type.
+  constexpr const char * __builtin_unique_stable_name( type-id );
+
+  // Computes a unique stable name for the type of the given expression.
+  constexpr const char * __builtin_unique_stable_name( expression );
 
 Multiprecision Arithmetic Builtins
 ----------------------------------

--- a/clang/docs/LanguageExtensions.rst
+++ b/clang/docs/LanguageExtensions.rst
@@ -2330,8 +2330,8 @@ Once this builtin is evaluated in a constexpr context, it is erroneous to use
 it in an instantiation which changes its value.
 
 In order to produce the unique name, the current implementation of the bultin
-uses Itanium mangling even if the host compilation may use a different name
-mangling scheme at runtime. The mangler mark all the lambdas required to name
+uses Itanium mangling even if the host compilation uses a different name
+mangling scheme at runtime. The mangler marks all the lambdas required to name
 the SYCL kernel and emits ``10000`` plus the aforementioned stable local
 ordering number of the respective lambdas. The resulting pattern is demanglable.
 Here ``10000`` is to serve as an obvious visual differentiator from ordinary

--- a/clang/include/clang/AST/ASTContext.h
+++ b/clang/include/clang/AST/ASTContext.h
@@ -3161,9 +3161,6 @@ private:
   /// `pragma omp [begin] declare variant` directive.
   SmallVector<std::unique_ptr<OMPTraitInfo>, 4> OMPTraitInfoVector;
 
-  // TODO: ERICH: This is what John McCall suggested as a structure. We need to
-  // figure out whether this is sufficient/right, since we have to figure out
-  // how to determine the required ordering here.
   /// A list of the (right now just lambda decls) tag declarations required to
   /// name all the SYCL kernels in the translation unit, so that we can get the
   /// correct kernel name, as well as implement __builtin_unique_stable_name.

--- a/clang/include/clang/AST/ASTContext.h
+++ b/clang/include/clang/AST/ASTContext.h
@@ -3152,10 +3152,23 @@ public:
 
   StringRef getCUIDHash() const;
 
+  void AddSYCLKernelNamingDecl(const TagDecl *TD);
+  bool IsSYCLKernelNamingDecl(const TagDecl *TD) const;
+  unsigned GetSYCLKernelNamingIndex(const TagDecl *TD) const;
+
 private:
   /// All OMPTraitInfo objects live in this collection, one per
   /// `pragma omp [begin] declare variant` directive.
   SmallVector<std::unique_ptr<OMPTraitInfo>, 4> OMPTraitInfoVector;
+
+  // TODO: ERICH: This is what John McCall suggested as a structure. We need to
+  // figure out whether this is sufficient/right, since we have to figure out
+  // how to determine the required ordering here.
+  /// A list of the (right now just lambda decls) tag declarations required to
+  /// name all the SYCL kernels in the translation unit, so that we can get the
+  /// correct kernel name, as well as implement __builtin_unique_stable_name.
+  llvm::DenseMap<const DeclContext *, llvm::SmallPtrSet<const TagDecl *, 4>>
+      SYCLKernelNamingTypes;
 };
 
 /// Insertion operator for diagnostics.

--- a/clang/include/clang/AST/ASTContext.h
+++ b/clang/include/clang/AST/ASTContext.h
@@ -3155,6 +3155,10 @@ public:
   void AddSYCLKernelNamingDecl(const TagDecl *TD);
   bool IsSYCLKernelNamingDecl(const TagDecl *TD) const;
   unsigned GetSYCLKernelNamingIndex(const TagDecl *TD) const;
+  /// A SourceLocation to store whether we have evaluated a kernel name already,
+  /// and where it happened.  If so, we need to diagnose an illegal use of the
+  /// builtin.
+  SourceLocation KernelNameEvaluatedFirst{};
 
 private:
   /// All OMPTraitInfo objects live in this collection, one per

--- a/clang/include/clang/AST/ASTContext.h
+++ b/clang/include/clang/AST/ASTContext.h
@@ -3158,7 +3158,8 @@ public:
   /// A SourceLocation to store whether we have evaluated a kernel name already,
   /// and where it happened.  If so, we need to diagnose an illegal use of the
   /// builtin.
-  SourceLocation KernelNameEvaluatedFirst{};
+  llvm::MapVector<const UniqueStableNameExpr *, std::string>
+      UniqueStableNameEvaluatedValues;
 
 private:
   /// All OMPTraitInfo objects live in this collection, one per

--- a/clang/include/clang/AST/ASTContext.h
+++ b/clang/include/clang/AST/ASTContext.h
@@ -3152,9 +3152,9 @@ public:
 
   StringRef getCUIDHash() const;
 
-  void AddSYCLKernelNamingDecl(const TagDecl *TD);
-  bool IsSYCLKernelNamingDecl(const TagDecl *TD) const;
-  unsigned GetSYCLKernelNamingIndex(const TagDecl *TD) const;
+  void AddSYCLKernelNamingDecl(const CXXRecordDecl *RD);
+  bool IsSYCLKernelNamingDecl(const CXXRecordDecl *RD) const;
+  unsigned GetSYCLKernelNamingIndex(const CXXRecordDecl *RD) const;
   /// A SourceLocation to store whether we have evaluated a kernel name already,
   /// and where it happened.  If so, we need to diagnose an illegal use of the
   /// builtin.
@@ -3166,10 +3166,11 @@ private:
   /// `pragma omp [begin] declare variant` directive.
   SmallVector<std::unique_ptr<OMPTraitInfo>, 4> OMPTraitInfoVector;
 
-  /// A list of the (right now just lambda decls) tag declarations required to
+  /// A list of the (right now just lambda decls) declarations required to
   /// name all the SYCL kernels in the translation unit, so that we can get the
   /// correct kernel name, as well as implement __builtin_unique_stable_name.
-  llvm::DenseMap<const DeclContext *, llvm::SmallPtrSet<const TagDecl *, 4>>
+  llvm::DenseMap<const DeclContext *,
+                 llvm::SmallPtrSet<const CXXRecordDecl *, 4>>
       SYCLKernelNamingTypes;
 };
 

--- a/clang/include/clang/AST/ComputeDependence.h
+++ b/clang/include/clang/AST/ComputeDependence.h
@@ -78,6 +78,7 @@ class MaterializeTemporaryExpr;
 class CXXFoldExpr;
 class TypeTraitExpr;
 class ConceptSpecializationExpr;
+class UniqueStableNameExpr;
 class PredefinedExpr;
 class CallExpr;
 class OffsetOfExpr;
@@ -165,6 +166,7 @@ ExprDependence computeDependence(TypeTraitExpr *E);
 ExprDependence computeDependence(ConceptSpecializationExpr *E,
                                  bool ValueDependent);
 
+ExprDependence computeDependence(UniqueStableNameExpr *E);
 ExprDependence computeDependence(PredefinedExpr *E);
 ExprDependence computeDependence(CallExpr *E, llvm::ArrayRef<Expr *> PreArgs);
 ExprDependence computeDependence(OffsetOfExpr *E);

--- a/clang/include/clang/AST/Expr.h
+++ b/clang/include/clang/AST/Expr.h
@@ -2143,7 +2143,7 @@ public:
   }
 
   // Convenience function to generate the name of the currently stored type.
-  std::string ComputeName(ASTContext &Context);
+  std::string ComputeName(ASTContext &Context) const;
 
   // Get the generated name of the type.  Note that this only works after all
   // kernels have been instantiated.

--- a/clang/include/clang/AST/Expr.h
+++ b/clang/include/clang/AST/Expr.h
@@ -2147,7 +2147,7 @@ public:
 
   // Get the generated name of the type.  Note that this only works after all
   // kernels have been instantiated.
-  static std::string Compute(ASTContext &Context, QualType Ty);
+  static std::string ComputeName(ASTContext &Context, QualType Ty);
 };
 
 /// ParenExpr - This represents a parethesized expression, e.g. "(1)".  This

--- a/clang/include/clang/AST/Expr.h
+++ b/clang/include/clang/AST/Expr.h
@@ -2040,7 +2040,7 @@ public:
 // This represents a use of the __builtin_unique_stable_name, which takes either
 // a type-id or an expression, and at CodeGen time emits a unique string
 // representation of the type (or type of the expression) in a way that permits
-// us to properly encode information about the SYCL Kernels.
+// us to properly encode information about the SYCL kernels.
 class UniqueStableNameExpr final
     : public Expr,
       private llvm::TrailingObjects<UniqueStableNameExpr, Stmt *,
@@ -2099,13 +2099,13 @@ public:
   Expr *getExpr() {
     assert(Kind == ParamKind::Expr &&
            "Expr only valid for UniqueStableName of an Expr");
-    return static_cast<Expr *>(*getTrailingObjects<Stmt *>());
+    return cast<Expr>(*getTrailingObjects<Stmt *>());
   }
 
   const Expr *getExpr() const {
     assert(Kind == ParamKind::Expr &&
            "Expr only valid for UniqueStableName of an Expr");
-    return static_cast<Expr *>(*getTrailingObjects<Stmt *>());
+    return cast<Expr>(*getTrailingObjects<Stmt *>());
   }
 
   bool isExpr() const { return Kind == ParamKind::Expr; }

--- a/clang/include/clang/AST/Expr.h
+++ b/clang/include/clang/AST/Expr.h
@@ -2141,6 +2141,10 @@ public:
     return const_child_range(getTrailingObjects<Stmt *>(),
                              getTrailingObjects<Stmt *>() + isExpr());
   }
+
+  // Get the generated name of the type.  Note that this only works after all
+  // kernels have been instantiated.
+  std::string ComputeName(ASTContext &Context);
 };
 
 /// ParenExpr - This represents a parethesized expression, e.g. "(1)".  This

--- a/clang/include/clang/AST/Expr.h
+++ b/clang/include/clang/AST/Expr.h
@@ -2142,9 +2142,12 @@ public:
                              getTrailingObjects<Stmt *>() + isExpr());
   }
 
+  // Convenience function to generate the name of the currently stored type.
+  std::string ComputeName(ASTContext &Context);
+
   // Get the generated name of the type.  Note that this only works after all
   // kernels have been instantiated.
-  std::string ComputeName(ASTContext &Context);
+  static std::string Compute(ASTContext &Context, QualType Ty);
 };
 
 /// ParenExpr - This represents a parethesized expression, e.g. "(1)".  This

--- a/clang/include/clang/AST/JSONNodeDumper.h
+++ b/clang/include/clang/AST/JSONNodeDumper.h
@@ -263,6 +263,7 @@ public:
   void VisitBlockDecl(const BlockDecl *D);
 
   void VisitDeclRefExpr(const DeclRefExpr *DRE);
+  void VisitUniqueStableNameExpr(const UniqueStableNameExpr *E);
   void VisitPredefinedExpr(const PredefinedExpr *PE);
   void VisitUnaryOperator(const UnaryOperator *UO);
   void VisitBinaryOperator(const BinaryOperator *BO);

--- a/clang/include/clang/AST/Mangle.h
+++ b/clang/include/clang/AST/Mangle.h
@@ -175,7 +175,8 @@ class ItaniumMangleContext : public MangleContext {
 public:
   // TODO: ERICH: this is obviously not going to be sufficient, type will change
   // during dev.
-  using KernelMangleCallbackTy = void (*)();
+  using KernelMangleCallbackTy = void (*)(ASTContext &, const TagDecl *,
+                                          raw_ostream &);
   explicit ItaniumMangleContext(ASTContext &C, DiagnosticsEngine &D)
       : MangleContext(C, D, MK_Itanium) {}
 

--- a/clang/include/clang/AST/Mangle.h
+++ b/clang/include/clang/AST/Mangle.h
@@ -173,7 +173,7 @@ public:
 
 class ItaniumMangleContext : public MangleContext {
 public:
-  using KernelMangleCallbackTy = void (*)(ASTContext &, const TagDecl *,
+  using KernelMangleCallbackTy = bool (*)(ASTContext &, const TagDecl *,
                                           raw_ostream &);
   explicit ItaniumMangleContext(ASTContext &C, DiagnosticsEngine &D)
       : MangleContext(C, D, MK_Itanium) {}

--- a/clang/include/clang/AST/Mangle.h
+++ b/clang/include/clang/AST/Mangle.h
@@ -173,6 +173,9 @@ public:
 
 class ItaniumMangleContext : public MangleContext {
 public:
+  // TODO: ERICH: this is obviously not going to be sufficient, type will change
+  // during dev.
+  using KernelMangleCallbackTy = void (*)();
   explicit ItaniumMangleContext(ASTContext &C, DiagnosticsEngine &D)
       : MangleContext(C, D, MK_Itanium) {}
 
@@ -195,12 +198,21 @@ public:
 
   virtual void mangleDynamicStermFinalizer(const VarDecl *D, raw_ostream &) = 0;
 
+  // This seemingly has to live here, otherwise the CXXNameMangler won't have
+  // access to it.
+  virtual KernelMangleCallbackTy getKernelMangleCallback() = 0;
+
   static bool classof(const MangleContext *C) {
     return C->getKind() == MK_Itanium;
   }
 
   static ItaniumMangleContext *create(ASTContext &Context,
                                       DiagnosticsEngine &Diags);
+  static ItaniumMangleContext *create(ASTContext &Context,
+                                      DiagnosticsEngine &Diags,
+                                      KernelMangleCallbackTy Callback);
+
+private:
 };
 
 class MicrosoftMangleContext : public MangleContext {

--- a/clang/include/clang/AST/Mangle.h
+++ b/clang/include/clang/AST/Mangle.h
@@ -173,7 +173,8 @@ public:
 
 class ItaniumMangleContext : public MangleContext {
 public:
-  using KernelMangleCallbackTy = bool (*)(ASTContext &, const TagDecl *,
+  using ShouldCallKernelCallbackTy = bool (*)(ASTContext &, const TagDecl *);
+  using KernelMangleCallbackTy = void (*)(ASTContext &, const TagDecl *,
                                           raw_ostream &);
   explicit ItaniumMangleContext(ASTContext &C, DiagnosticsEngine &D)
       : MangleContext(C, D, MK_Itanium) {}
@@ -197,8 +198,9 @@ public:
 
   virtual void mangleDynamicStermFinalizer(const VarDecl *D, raw_ostream &) = 0;
 
-  // This seemingly has to live here, otherwise the CXXNameMangler won't have
-  // access to it.
+  // These have to live here, otherwise the CXXNameMangler won't have access to
+  // them.
+  virtual ShouldCallKernelCallbackTy getShouldCallKernelCallback() const = 0;
   virtual KernelMangleCallbackTy getKernelMangleCallback() const = 0;
 
   static bool classof(const MangleContext *C) {
@@ -207,10 +209,10 @@ public:
 
   static ItaniumMangleContext *create(ASTContext &Context,
                                       DiagnosticsEngine &Diags);
-  static ItaniumMangleContext *create(ASTContext &Context,
-                                      DiagnosticsEngine &Diags,
-                                      KernelMangleCallbackTy Callback);
-
+  static ItaniumMangleContext *
+  create(ASTContext &Context, DiagnosticsEngine &Diags,
+         ShouldCallKernelCallbackTy ShouldKernelMangleCB,
+         KernelMangleCallbackTy KernelMangleCB);
 };
 
 class MicrosoftMangleContext : public MangleContext {

--- a/clang/include/clang/AST/Mangle.h
+++ b/clang/include/clang/AST/Mangle.h
@@ -173,8 +173,6 @@ public:
 
 class ItaniumMangleContext : public MangleContext {
 public:
-  // TODO: ERICH: this is obviously not going to be sufficient, type will change
-  // during dev.
   using KernelMangleCallbackTy = void (*)(ASTContext &, const TagDecl *,
                                           raw_ostream &);
   explicit ItaniumMangleContext(ASTContext &C, DiagnosticsEngine &D)

--- a/clang/include/clang/AST/Mangle.h
+++ b/clang/include/clang/AST/Mangle.h
@@ -200,7 +200,7 @@ public:
 
   // This seemingly has to live here, otherwise the CXXNameMangler won't have
   // access to it.
-  virtual KernelMangleCallbackTy getKernelMangleCallback() = 0;
+  virtual KernelMangleCallbackTy getKernelMangleCallback() const = 0;
 
   static bool classof(const MangleContext *C) {
     return C->getKind() == MK_Itanium;
@@ -212,7 +212,6 @@ public:
                                       DiagnosticsEngine &Diags,
                                       KernelMangleCallbackTy Callback);
 
-private:
 };
 
 class MicrosoftMangleContext : public MangleContext {

--- a/clang/include/clang/AST/Mangle.h
+++ b/clang/include/clang/AST/Mangle.h
@@ -173,8 +173,9 @@ public:
 
 class ItaniumMangleContext : public MangleContext {
 public:
-  using ShouldCallKernelCallbackTy = bool (*)(ASTContext &, const TagDecl *);
-  using KernelMangleCallbackTy = void (*)(ASTContext &, const TagDecl *,
+  using ShouldCallKernelCallbackTy = bool (*)(ASTContext &,
+                                              const CXXRecordDecl *);
+  using KernelMangleCallbackTy = void (*)(ASTContext &, const CXXRecordDecl *,
                                           raw_ostream &);
   explicit ItaniumMangleContext(ASTContext &C, DiagnosticsEngine &D)
       : MangleContext(C, D, MK_Itanium) {}

--- a/clang/include/clang/AST/RecursiveASTVisitor.h
+++ b/clang/include/clang/AST/RecursiveASTVisitor.h
@@ -2636,6 +2636,12 @@ DEF_TRAVERSE_STMT(ObjCBridgedCastExpr, {
 DEF_TRAVERSE_STMT(ObjCAvailabilityCheckExpr, {})
 DEF_TRAVERSE_STMT(ParenExpr, {})
 DEF_TRAVERSE_STMT(ParenListExpr, {})
+DEF_TRAVERSE_STMT(UniqueStableNameExpr, {
+  if (S->isExpr())
+    TRY_TO(TraverseStmt(S->getExpr()));
+  else
+    TRY_TO(TraverseTypeLoc(S->getTypeSourceInfo()->getTypeLoc()));
+})
 DEF_TRAVERSE_STMT(PredefinedExpr, {})
 DEF_TRAVERSE_STMT(ShuffleVectorExpr, {})
 DEF_TRAVERSE_STMT(ConvertVectorExpr, {})

--- a/clang/include/clang/AST/RecursiveASTVisitor.h
+++ b/clang/include/clang/AST/RecursiveASTVisitor.h
@@ -2637,9 +2637,7 @@ DEF_TRAVERSE_STMT(ObjCAvailabilityCheckExpr, {})
 DEF_TRAVERSE_STMT(ParenExpr, {})
 DEF_TRAVERSE_STMT(ParenListExpr, {})
 DEF_TRAVERSE_STMT(UniqueStableNameExpr, {
-  if (S->isExpr())
-    TRY_TO(TraverseStmt(S->getExpr()));
-  else
+  if (S->isTypeSourceInfo())
     TRY_TO(TraverseTypeLoc(S->getTypeSourceInfo()->getTypeLoc()));
 })
 DEF_TRAVERSE_STMT(PredefinedExpr, {})

--- a/clang/include/clang/AST/TextNodeDumper.h
+++ b/clang/include/clang/AST/TextNodeDumper.h
@@ -249,6 +249,7 @@ public:
   void VisitCastExpr(const CastExpr *Node);
   void VisitImplicitCastExpr(const ImplicitCastExpr *Node);
   void VisitDeclRefExpr(const DeclRefExpr *Node);
+  void VisitUniqueStableNameExpr(const UniqueStableNameExpr *Node);
   void VisitPredefinedExpr(const PredefinedExpr *Node);
   void VisitCharacterLiteral(const CharacterLiteral *Node);
   void VisitIntegerLiteral(const IntegerLiteral *Node);

--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -325,7 +325,8 @@ def MicrosoftExt : LangOpt<"MicrosoftExt">;
 def Borland : LangOpt<"Borland">;
 def CUDA : LangOpt<"CUDA">;
 def HIP : LangOpt<"HIP">;
-def SYCL : LangOpt<"SYCLIsDevice">;
+def SYCLDevice : LangOpt<"SYCLIsDevice">;
+def SYCLHost : LangOpt<"SYCLIsDevice">;
 def COnly : LangOpt<"", "!LangOpts.CPlusPlus">;
 def CPlusPlus : LangOpt<"CPlusPlus">;
 def OpenCL : LangOpt<"OpenCL">;
@@ -1171,7 +1172,7 @@ def : MutualExclusions<[CUDAConstant, CUDAShared, HIPManaged]>;
 def SYCLKernel : InheritableAttr {
   let Spellings = [Clang<"sycl_kernel">];
   let Subjects = SubjectList<[FunctionTmpl]>;
-  let LangOpts = [SYCL];
+  let LangOpts = [SYCLDevice, SYCLHost];
   let Documentation = [SYCLKernelDocs];
 }
 

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -6333,9 +6333,9 @@ def warn_gnu_null_ptr_arith : Warning<
   InGroup<NullPointerArithmetic>, DefaultIgnore;
 def err_kernel_invalidates_unique_stable_name
     : Error<"kernel instantiation changes the result of an evaluated "
-            "__builtin_unique_stable_name">;
+            "'__builtin_unique_stable_name'">;
 def note_unique_stable_name_evaluated_here
-    : Note<"__builtin_unique_stable_name evaluated here">;
+    : Note<"'__builtin_unique_stable_name' evaluated here">;
 
 def warn_floatingpoint_eq : Warning<
   "comparing floating point with == or != is unsafe">,

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -6331,6 +6331,10 @@ def warn_pointer_arith_null_ptr : Warning<
 def warn_gnu_null_ptr_arith : Warning<
   "arithmetic on a null pointer treated as a cast from integer to pointer is a GNU extension">,
   InGroup<NullPointerArithmetic>, DefaultIgnore;
+def err_unique_stable_name_already_evaluated
+    : Error<"__builtin_unique_stable_name evaluated before the last kernel was "
+            "instantiated">;
+def note_kernel_instantiated_here : Note<"kernel instantiated here">;
 
 def warn_floatingpoint_eq : Warning<
   "comparing floating point with == or != is unsafe">,

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -6331,10 +6331,11 @@ def warn_pointer_arith_null_ptr : Warning<
 def warn_gnu_null_ptr_arith : Warning<
   "arithmetic on a null pointer treated as a cast from integer to pointer is a GNU extension">,
   InGroup<NullPointerArithmetic>, DefaultIgnore;
-def err_unique_stable_name_already_evaluated
-    : Error<"__builtin_unique_stable_name evaluated before the last kernel was "
-            "instantiated">;
-def note_kernel_instantiated_here : Note<"kernel instantiated here">;
+def err_kernel_invalidates_unique_stable_name
+    : Error<"kernel instantiation changes the result of an evaluated "
+            "__builtin_unique_stable_name">;
+def note_unique_stable_name_evaluated_here
+    : Note<"__builtin_unique_stable_name evaluated here">;
 
 def warn_floatingpoint_eq : Warning<
   "comparing floating point with == or != is unsafe">,

--- a/clang/include/clang/Basic/StmtNodes.td
+++ b/clang/include/clang/Basic/StmtNodes.td
@@ -57,6 +57,7 @@ def CoreturnStmt : StmtNode<Stmt>;
 // Expressions
 def Expr : StmtNode<ValueStmt, 1>;
 def PredefinedExpr : StmtNode<Expr>;
+def UniqueStableNameExpr : StmtNode<Expr>;
 def DeclRefExpr : StmtNode<Expr>;
 def IntegerLiteral : StmtNode<Expr>;
 def FixedPointLiteral : StmtNode<Expr>;

--- a/clang/include/clang/Basic/TokenKinds.def
+++ b/clang/include/clang/Basic/TokenKinds.def
@@ -699,6 +699,7 @@ ALIAS("__char16_t"   , char16_t     , KEYCXX)
 ALIAS("__char32_t"   , char32_t     , KEYCXX)
 KEYWORD(__builtin_bit_cast          , KEYALL)
 KEYWORD(__builtin_available         , KEYALL)
+KEYWORD(__builtin_unique_stable_name, KEYALL)
 
 // Clang-specific keywords enabled only in testing.
 TESTING_KEYWORD(__unknown_anytype , KEYALL)

--- a/clang/include/clang/Parse/Parser.h
+++ b/clang/include/clang/Parse/Parser.h
@@ -1797,6 +1797,7 @@ private:
   ExprResult ParsePostfixExpressionSuffix(ExprResult LHS);
   ExprResult ParseUnaryExprOrTypeTraitExpression();
   ExprResult ParseBuiltinPrimaryExpression();
+  ExprResult ParseUniqueStableNameExpression();
 
   ExprResult ParseExprAfterUnaryExprOrTypeTrait(const Token &OpTok,
                                                      bool &isCastExpr,

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -914,6 +914,10 @@ public:
     OpaqueParser = P;
   }
 
+  // Does the work necessary to deal with a SYCL kernel lambda. At the moment,
+  // this just marks the list of lambdas required to name the kernel.
+  void AddSYCLKernelLambda(const FunctionDecl *FD);
+
   class DelayedDiagnostics;
 
   class DelayedDiagnosticsState {

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -5176,9 +5176,17 @@ public:
   ExprResult ActOnPredefinedExpr(SourceLocation Loc, tok::TokenKind Kind);
   ExprResult ActOnIntegerConstant(SourceLocation Loc, uint64_t Val);
 
+  ExprResult BuildUniqueStableNameExpr(SourceLocation OpLoc,
+                                       SourceLocation LParen,
+                                       SourceLocation RParen,
+                                       TypeSourceInfo *TSI);
+  ExprResult BuildUniqueStableNameExpr(SourceLocation OpLoc,
+                                       SourceLocation LParen,
+                                       SourceLocation RParen, Expr *E);
   ExprResult ActOnUniqueStableNameExpr(SourceLocation OpLoc,
                                        SourceLocation LParen,
-                                       SourceLocation RParen, ParsedType Ty);
+                                       SourceLocation RParen,
+                                       ParsedType ParsedTy);
   ExprResult ActOnUniqueStableNameExpr(SourceLocation OpLoc,
                                        SourceLocation LParen,
                                        SourceLocation RParen, Expr *Operand);

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -5176,6 +5176,13 @@ public:
   ExprResult ActOnPredefinedExpr(SourceLocation Loc, tok::TokenKind Kind);
   ExprResult ActOnIntegerConstant(SourceLocation Loc, uint64_t Val);
 
+  ExprResult ActOnUniqueStableNameExpr(SourceLocation OpLoc,
+                                       SourceLocation LParen,
+                                       SourceLocation RParen, ParsedType Ty);
+  ExprResult ActOnUniqueStableNameExpr(SourceLocation OpLoc,
+                                       SourceLocation LParen,
+                                       SourceLocation RParen, Expr *Operand);
+
   bool CheckLoopHintExpr(Expr *E, SourceLocation Loc);
 
   ExprResult ActOnNumericConstant(const Token &Tok, Scope *UDLScope = nullptr);

--- a/clang/include/clang/Serialization/ASTBitCodes.h
+++ b/clang/include/clang/Serialization/ASTBitCodes.h
@@ -1960,6 +1960,9 @@ enum StmtCode {
 
   // FixedPointLiteral
   EXPR_FIXEDPOINT_LITERAL,
+
+  // UniqueStableNameExpr
+  EXPR_UNIQUESTABLENAME,
 };
 
 /// The kinds of designators that can occur in a

--- a/clang/lib/AST/ASTContext.cpp
+++ b/clang/lib/AST/ASTContext.cpp
@@ -2448,7 +2448,7 @@ unsigned ASTContext::getPreferredTypeAlign(const Type *T) const {
   // The preferred alignment of member pointers is that of a pointer.
   if (T->isMemberPointerType())
     return getPreferredTypeAlign(getPointerDiffType().getTypePtr());
-
+ 
   if (!Target->allowsLargerPreferedTypeAlignment())
     return ABIAlign;
 

--- a/clang/lib/AST/ASTContext.cpp
+++ b/clang/lib/AST/ASTContext.cpp
@@ -11664,6 +11664,9 @@ unsigned ASTContext::GetSYCLKernelNamingIndex(const TagDecl *TD) const {
 
   // TODO: ERICH: Come up with some way to sort the collection and come up with
   // an 'order' for this number.  For now, just return 5 so we can look at it in
-  // the demangler.
+  // the demangler. It seems that a number is all we can do in the lambda
+  // mangling, but if someone else has a better mangling-model that always
+  // demangles, let me know.  We might think about counting these down from
+  // unsigned-max just to differentiate.
   return 5;
 }

--- a/clang/lib/AST/ASTContext.cpp
+++ b/clang/lib/AST/ASTContext.cpp
@@ -11679,14 +11679,14 @@ unsigned ASTContext::GetSYCLKernelNamingIndex(const TagDecl *TD) const {
   const DeclContext *DC = GetNamedParent(TD);
 
   auto Itr = SYCLKernelNamingTypes.find(DC);
-  assert (Itr != SYCLKernelNamingTypes.end() && "Not a valid DeclContext?");
+  assert(Itr != SYCLKernelNamingTypes.end() && "Not a valid DeclContext?");
 
-  const llvm::SmallPtrSet<const TagDecl*, 4> &Set = Itr->getSecond();
+  const llvm::SmallPtrSet<const TagDecl *, 4> &Set = Itr->getSecond();
 
   llvm::SmallVector<const TagDecl *> TagDecls{Set.begin(), Set.end()};
   llvm::sort(TagDecls, [](const TagDecl *LHS, const TagDecl *RHS) {
-             return LHS->getLocation() < RHS->getLocation();
-             });
+    return LHS->getLocation() < RHS->getLocation();
+  });
 
   return llvm::find(TagDecls, TD) - TagDecls.begin();
 }

--- a/clang/lib/AST/ASTContext.cpp
+++ b/clang/lib/AST/ASTContext.cpp
@@ -2448,7 +2448,7 @@ unsigned ASTContext::getPreferredTypeAlign(const Type *T) const {
   // The preferred alignment of member pointers is that of a pointer.
   if (T->isMemberPointerType())
     return getPreferredTypeAlign(getPointerDiffType().getTypePtr());
- 
+
   if (!Target->allowsLargerPreferedTypeAlignment())
     return ABIAlign;
 
@@ -11637,4 +11637,33 @@ StringRef ASTContext::getCUIDHash() const {
     return StringRef();
   CUIDHash = llvm::utohexstr(llvm::MD5Hash(LangOpts.CUID), /*LowerCase=*/true);
   return CUIDHash;
+}
+
+void ASTContext::AddSYCLKernelNamingDecl(const TagDecl *TD) {
+  TD = TD->getCanonicalDecl();
+  const DeclContext *DC = TD->getDeclContext();
+
+  (void)SYCLKernelNamingTypes[DC].insert(TD);
+}
+
+bool ASTContext::IsSYCLKernelNamingDecl(const TagDecl *TD) const {
+  TD = TD->getCanonicalDecl();
+  const DeclContext *DC = TD->getDeclContext();
+
+  auto Itr = SYCLKernelNamingTypes.find(DC);
+
+  if (Itr == SYCLKernelNamingTypes.end())
+    return false;
+
+  return Itr->getSecond().count(TD);
+}
+
+unsigned ASTContext::GetSYCLKernelNamingIndex(const TagDecl *TD) const {
+  assert(IsSYCLKernelNamingDecl(TD) &&
+         "Lambda not involved in mangling asked for a naming index?");
+
+  // TODO: ERICH: Come up with some way to sort the collection and come up with
+  // an 'order' for this number.  For now, just return 5 so we can look at it in
+  // the demangler.
+  return 5;
 }

--- a/clang/lib/AST/ComputeDependence.cpp
+++ b/clang/lib/AST/ComputeDependence.cpp
@@ -556,6 +556,12 @@ ExprDependence clang::computeDependence(RecoveryExpr *E) {
   return D;
 }
 
+ExprDependence clang::computeDependence(UniqueStableNameExpr *E) {
+  if (E->isExpr())
+    return E->getExpr()->getDependence();
+  return toExprDependence(E->getTypeSourceInfo()->getType()->getDependence());
+}
+
 ExprDependence clang::computeDependence(PredefinedExpr *E) {
   return toExprDependence(E->getType()->getDependence()) &
          ~ExprDependence::UnexpandedPack;

--- a/clang/lib/AST/Expr.cpp
+++ b/clang/lib/AST/Expr.cpp
@@ -571,14 +571,14 @@ std::string UniqueStableNameExpr::ComputeName(ASTContext &Context) {
   auto MangleCallback = [](ASTContext &Ctx, const TagDecl *TD,
                            raw_ostream &OS) {
     assert(Ctx.IsSYCLKernelNamingDecl(TD) && "Not a sycl kernel?");
-
-    // TODO: Can we put something here to make it clear this is a SYCL
-    // lambda? It seems the number in this location is about all I can
-    // find for us.
-    //
-    // See: _ZTSZ3foovEUlvE5_
-    // Demangles to: typeinfo name for foo()::'lambda5'()
-    OS << Ctx.GetSYCLKernelNamingIndex(TD);
+    // This replaces the 'lambda number' in the mangling with a unique number
+    // based on its order in the declaration.  To provide some level of visual
+    // notability (actual uniqueness from normal lambdas isn't necessary, as
+    // these are used differently), we add 10,000 to the number.
+    // For example:
+    // _ZTSZ3foovEUlvE10005_
+    // Demangles to: typeinfo name for foo()::'lambda10005'()
+    OS << (10'000 + Ctx.GetSYCLKernelNamingIndex(TD));
   };
   std::unique_ptr<MangleContext> Ctx{ItaniumMangleContext::create(
       Context, Context.getDiagnostics(), ShouldMangleCallback, MangleCallback)};

--- a/clang/lib/AST/Expr.cpp
+++ b/clang/lib/AST/Expr.cpp
@@ -565,6 +565,20 @@ UniqueStableNameExpr *UniqueStableNameExpr::CreateEmpty(const ASTContext &Ctx,
   return new (Mem) UniqueStableNameExpr(EmptyShell(), ResultTy, IsExpr);
 }
 
+std::string UniqueStableNameExpr::ComputeName(ASTContext &Context) {
+  auto Callback = []() { /*TODO ERICH: Implement*/ };
+  std::unique_ptr<MangleContext> Ctx{ItaniumMangleContext::create(
+      Context, Context.getDiagnostics(), Callback)};
+
+  QualType Ty = getTypeSourceInfo()->getType();
+  std::string Buffer;
+  Buffer.reserve(128);
+  llvm::raw_string_ostream Out(Buffer);
+  Ctx->mangleTypeName(Ty, Out);
+
+  return std::move(Buffer);
+}
+
 PredefinedExpr::PredefinedExpr(SourceLocation L, QualType FNTy, IdentKind IK,
                                StringLiteral *SL)
     : Expr(PredefinedExprClass, FNTy, VK_LValue, OK_Ordinary) {

--- a/clang/lib/AST/Expr.cpp
+++ b/clang/lib/AST/Expr.cpp
@@ -565,6 +565,12 @@ UniqueStableNameExpr *UniqueStableNameExpr::CreateEmpty(const ASTContext &Ctx,
 }
 
 std::string UniqueStableNameExpr::ComputeName(ASTContext &Context) {
+  return UniqueStableNameExpr::ComputeName(Context,
+                                           getTypeSourceInfo()->getType());
+}
+
+static std::string UniqueStableNameExpr::ComputeName(ASTContext &Context,
+                                                     QualType Ty) {
   auto ShouldMangleCallback = [](ASTContext &Ctx, const TagDecl *TD) {
     return Ctx.IsSYCLKernelNamingDecl(TD);
   };
@@ -583,7 +589,6 @@ std::string UniqueStableNameExpr::ComputeName(ASTContext &Context) {
   std::unique_ptr<MangleContext> Ctx{ItaniumMangleContext::create(
       Context, Context.getDiagnostics(), ShouldMangleCallback, MangleCallback)};
 
-  QualType Ty = getTypeSourceInfo()->getType();
   std::string Buffer;
   Buffer.reserve(128);
   llvm::raw_string_ostream Out(Buffer);

--- a/clang/lib/AST/Expr.cpp
+++ b/clang/lib/AST/Expr.cpp
@@ -566,7 +566,8 @@ UniqueStableNameExpr *UniqueStableNameExpr::CreateEmpty(const ASTContext &Ctx,
 }
 
 std::string UniqueStableNameExpr::ComputeName(ASTContext &Context) {
-  auto Callback = []() { /*TODO ERICH: Implement*/ };
+  auto Callback = [](ASTContext &Ctx, const TagDecl *TD,
+                     raw_ostream &OS) { /*TODO ERICH: Implement*/ };
   std::unique_ptr<MangleContext> Ctx{ItaniumMangleContext::create(
       Context, Context.getDiagnostics(), Callback)};
 

--- a/clang/lib/AST/Expr.cpp
+++ b/clang/lib/AST/Expr.cpp
@@ -564,7 +564,7 @@ UniqueStableNameExpr *UniqueStableNameExpr::CreateEmpty(const ASTContext &Ctx,
   return new (Mem) UniqueStableNameExpr(EmptyShell(), ResultTy, IsExpr);
 }
 
-std::string UniqueStableNameExpr::ComputeName(ASTContext &Context) {
+std::string UniqueStableNameExpr::ComputeName(ASTContext &Context) const {
   return UniqueStableNameExpr::ComputeName(Context,
                                            getTypeSourceInfo()->getType());
 }

--- a/clang/lib/AST/Expr.cpp
+++ b/clang/lib/AST/Expr.cpp
@@ -570,7 +570,7 @@ std::string UniqueStableNameExpr::ComputeName(ASTContext &Context) {
 }
 
 std::string UniqueStableNameExpr::ComputeName(ASTContext &Context,
-                                                     QualType Ty) {
+                                              QualType Ty) {
   auto ShouldMangleCallback = [](ASTContext &Ctx, const TagDecl *TD) {
     return Ctx.IsSYCLKernelNamingDecl(TD);
   };

--- a/clang/lib/AST/Expr.cpp
+++ b/clang/lib/AST/Expr.cpp
@@ -508,7 +508,7 @@ UniqueStableNameExpr::UniqueStableNameExpr(SourceLocation OpLoc,
                                            SourceLocation RParen,
                                            QualType ResultTy,
                                            TypeSourceInfo *TSI)
-    : Expr(UniqueStableNameExprClass, ResultTy, VK_LValue, OK_Ordinary),
+    : Expr(UniqueStableNameExprClass, ResultTy, VK_RValue, OK_Ordinary),
       OpLoc(OpLoc), LParen(LParen), RParen(RParen), Kind(ParamKind::Type) {
   setTypeSourceInfo(TSI);
   // Fixme: Do we have to do anything to make this work?
@@ -517,7 +517,7 @@ UniqueStableNameExpr::UniqueStableNameExpr(SourceLocation OpLoc,
 
 UniqueStableNameExpr::UniqueStableNameExpr(EmptyShell Empty, QualType ResultTy,
                                            bool IsExpr)
-    : Expr(UniqueStableNameExprClass, ResultTy, VK_LValue, OK_Ordinary) {
+    : Expr(UniqueStableNameExprClass, ResultTy, VK_RValue, OK_Ordinary) {
   Kind = IsExpr ? ParamKind::Expr : ParamKind::Expr;
 }
 
@@ -525,7 +525,7 @@ UniqueStableNameExpr::UniqueStableNameExpr(SourceLocation OpLoc,
                                            SourceLocation LParen,
                                            SourceLocation RParen,
                                            QualType ResultTy, Expr *E)
-    : Expr(UniqueStableNameExprClass, ResultTy, VK_LValue, OK_Ordinary),
+    : Expr(UniqueStableNameExprClass, ResultTy, VK_RValue, OK_Ordinary),
       OpLoc(OpLoc), LParen(LParen), RParen(RParen), Kind(ParamKind::Expr) {
   setExpr(E);
   setDependence(computeDependence(this));

--- a/clang/lib/AST/Expr.cpp
+++ b/clang/lib/AST/Expr.cpp
@@ -511,14 +511,13 @@ UniqueStableNameExpr::UniqueStableNameExpr(SourceLocation OpLoc,
     : Expr(UniqueStableNameExprClass, ResultTy, VK_RValue, OK_Ordinary),
       OpLoc(OpLoc), LParen(LParen), RParen(RParen), Kind(ParamKind::Type) {
   setTypeSourceInfo(TSI);
-  // Fixme: Do we have to do anything to make this work?
   setDependence(computeDependence(this));
 }
 
 UniqueStableNameExpr::UniqueStableNameExpr(EmptyShell Empty, QualType ResultTy,
                                            bool IsExpr)
     : Expr(UniqueStableNameExprClass, ResultTy, VK_RValue, OK_Ordinary) {
-  Kind = IsExpr ? ParamKind::Expr : ParamKind::Expr;
+  Kind = IsExpr ? ParamKind::Expr : ParamKind::Type;
 }
 
 UniqueStableNameExpr::UniqueStableNameExpr(SourceLocation OpLoc,

--- a/clang/lib/AST/Expr.cpp
+++ b/clang/lib/AST/Expr.cpp
@@ -570,7 +570,12 @@ std::string UniqueStableNameExpr::ComputeName(ASTContext &Context) {
     if (!Ctx.IsSYCLKernelNamingDecl(TD))
       return false;
 
-    OS << "SCYL_" << Ctx.GetSYCLKernelNamingIndex(TD);
+    // TODO: Can we put something here to make it clear this is a SYCL lambda?
+    // It seems the number in this location is about all I can find for us.
+    //
+    // See: _ZTSZ3foovEUlvE5_
+    // Demangles to: typeinfo name for foo()::'lambda5'()
+    OS <<  Ctx.GetSYCLKernelNamingIndex(TD);
     return true;
   };
   std::unique_ptr<MangleContext> Ctx{ItaniumMangleContext::create(

--- a/clang/lib/AST/Expr.cpp
+++ b/clang/lib/AST/Expr.cpp
@@ -566,8 +566,13 @@ UniqueStableNameExpr *UniqueStableNameExpr::CreateEmpty(const ASTContext &Ctx,
 }
 
 std::string UniqueStableNameExpr::ComputeName(ASTContext &Context) {
-  auto Callback = [](ASTContext &Ctx, const TagDecl *TD,
-                     raw_ostream &OS) { /*TODO ERICH: Implement*/ };
+  auto Callback = [](ASTContext &Ctx, const TagDecl *TD, raw_ostream &OS) {
+    if (!Ctx.IsSYCLKernelNamingDecl(TD))
+      return false;
+
+    OS << "SCYL_" << Ctx.GetSYCLKernelNamingIndex(TD);
+    return true;
+  };
   std::unique_ptr<MangleContext> Ctx{ItaniumMangleContext::create(
       Context, Context.getDiagnostics(), Callback)};
 

--- a/clang/lib/AST/Expr.cpp
+++ b/clang/lib/AST/Expr.cpp
@@ -569,7 +569,7 @@ std::string UniqueStableNameExpr::ComputeName(ASTContext &Context) {
                                            getTypeSourceInfo()->getType());
 }
 
-static std::string UniqueStableNameExpr::ComputeName(ASTContext &Context,
+std::string UniqueStableNameExpr::ComputeName(ASTContext &Context,
                                                      QualType Ty) {
   auto ShouldMangleCallback = [](ASTContext &Ctx, const TagDecl *TD) {
     return Ctx.IsSYCLKernelNamingDecl(TD);

--- a/clang/lib/AST/Expr.cpp
+++ b/clang/lib/AST/Expr.cpp
@@ -594,7 +594,7 @@ std::string UniqueStableNameExpr::ComputeName(ASTContext &Context,
   llvm::raw_string_ostream Out(Buffer);
   Ctx->mangleTypeName(Ty, Out);
 
-  return std::move(Buffer);
+  return Out.str();
 }
 
 PredefinedExpr::PredefinedExpr(SourceLocation L, QualType FNTy, IdentKind IK,

--- a/clang/lib/AST/Expr.cpp
+++ b/clang/lib/AST/Expr.cpp
@@ -571,12 +571,12 @@ std::string UniqueStableNameExpr::ComputeName(ASTContext &Context) const {
 
 std::string UniqueStableNameExpr::ComputeName(ASTContext &Context,
                                               QualType Ty) {
-  auto ShouldMangleCallback = [](ASTContext &Ctx, const TagDecl *TD) {
-    return Ctx.IsSYCLKernelNamingDecl(TD);
+  auto ShouldMangleCallback = [](ASTContext &Ctx, const CXXRecordDecl *RD) {
+    return Ctx.IsSYCLKernelNamingDecl(RD);
   };
-  auto MangleCallback = [](ASTContext &Ctx, const TagDecl *TD,
+  auto MangleCallback = [](ASTContext &Ctx, const CXXRecordDecl *RD,
                            raw_ostream &OS) {
-    assert(Ctx.IsSYCLKernelNamingDecl(TD) && "Not a sycl kernel?");
+    assert(Ctx.IsSYCLKernelNamingDecl(RD) && "Not a sycl kernel?");
     // This replaces the 'lambda number' in the mangling with a unique number
     // based on its order in the declaration.  To provide some level of visual
     // notability (actual uniqueness from normal lambdas isn't necessary, as
@@ -584,7 +584,7 @@ std::string UniqueStableNameExpr::ComputeName(ASTContext &Context,
     // For example:
     // _ZTSZ3foovEUlvE10005_
     // Demangles to: typeinfo name for foo()::'lambda10005'()
-    OS << (10'000 + Ctx.GetSYCLKernelNamingIndex(TD));
+    OS << (10'000 + Ctx.GetSYCLKernelNamingIndex(RD));
   };
   std::unique_ptr<MangleContext> Ctx{ItaniumMangleContext::create(
       Context, Context.getDiagnostics(), ShouldMangleCallback, MangleCallback)};

--- a/clang/lib/AST/ExprClassification.cpp
+++ b/clang/lib/AST/ExprClassification.cpp
@@ -434,7 +434,7 @@ static Cl::Kinds ClassifyInternal(ASTContext &Ctx, const Expr *E) {
   case Expr::CoyieldExprClass:
     return ClassifyInternal(Ctx, cast<CoroutineSuspendExpr>(E)->getResumeExpr());
   case Expr::UniqueStableNameExprClass:
-    // TODO: ERICH! Figure out how to handle this.
+    return Cl::CL_PRValue;
     break;
   }
 

--- a/clang/lib/AST/ExprClassification.cpp
+++ b/clang/lib/AST/ExprClassification.cpp
@@ -433,6 +433,9 @@ static Cl::Kinds ClassifyInternal(ASTContext &Ctx, const Expr *E) {
   case Expr::CoawaitExprClass:
   case Expr::CoyieldExprClass:
     return ClassifyInternal(Ctx, cast<CoroutineSuspendExpr>(E)->getResumeExpr());
+  case Expr::UniqueStableNameExprClass:
+    // TODO: ERICH! Figure out how to handle this.
+    break;
   }
 
   llvm_unreachable("unhandled expression kind in classification");

--- a/clang/lib/AST/ExprConstant.cpp
+++ b/clang/lib/AST/ExprConstant.cpp
@@ -8675,7 +8675,8 @@ public:
     Info.Ctx.UniqueStableNameEvaluatedValues[E] = ResultStr;
 
     QualType CharTy = Info.Ctx.CharTy.withConst();
-    APInt Size(Info.Ctx.getTypeSize(Info.Ctx.getSizeType()), ResultStr.size());
+    APInt Size(Info.Ctx.getTypeSize(Info.Ctx.getSizeType()),
+               ResultStr.size() + 1);
     QualType ArrayTy = Info.Ctx.getConstantArrayType(CharTy, Size, nullptr,
                                                      ArrayType::Normal, 0);
 

--- a/clang/lib/AST/ExprConstant.cpp
+++ b/clang/lib/AST/ExprConstant.cpp
@@ -15154,6 +15154,7 @@ static ICEDiag CheckICE(const Expr* E, const ASTContext &Ctx) {
   case Expr::CoawaitExprClass:
   case Expr::DependentCoawaitExprClass:
   case Expr::CoyieldExprClass:
+  case Expr::UniqueStableNameExprClass:
     return ICEDiag(IK_NotICE, E->getBeginLoc());
 
   case Expr::InitListExprClass: {

--- a/clang/lib/AST/ExprConstant.cpp
+++ b/clang/lib/AST/ExprConstant.cpp
@@ -8670,11 +8670,10 @@ public:
   }
 
   bool VisitUniqueStableNameExpr(const UniqueStableNameExpr *E) {
-    if (Info.Ctx.KernelNameEvaluatedFirst.isInvalid())
-      Info.Ctx.KernelNameEvaluatedFirst = E->getLocation();
-
-    // TODO: ERICH: Do we have any idea if this is the right way to do this?
     std::string ResultStr = E->ComputeName(Info.Ctx);
+
+    Info.Ctx.UniqueStableNameEvaluatedValues[E] = ResultStr;
+
     QualType CharTy = Info.Ctx.CharTy.withConst();
     APInt Size(Info.Ctx.getTypeSize(Info.Ctx.getSizeType()), ResultStr.size());
     QualType ArrayTy = Info.Ctx.getConstantArrayType(CharTy, Size, nullptr,

--- a/clang/lib/AST/ItaniumMangle.cpp
+++ b/clang/lib/AST/ItaniumMangle.cpp
@@ -1937,8 +1937,10 @@ void CXXNameMangler::mangleLambda(const CXXRecordDecl *Lambda) {
     // If this is involved in kernel mangling and we are in the
     // __builtin_unique_stable_name parts, this function returns 'true', so we
     // skip the 'number' apend.
-    if (CB(Context.getASTContext(), Lambda, Out))
+    if (CB(Context.getASTContext(), Lambda, Out)) {
+      Out << '_';
       return;
+    }
   } else {
     // Don't assert in the kernel __builtin_unique_stable_name part, since that
     // just needs to be internally consistent with itself. Having it be

--- a/clang/lib/AST/ItaniumMangle.cpp
+++ b/clang/lib/AST/ItaniumMangle.cpp
@@ -4093,8 +4093,6 @@ recurse:
   case Expr::OMPIteratorExprClass:
   case Expr::CXXInheritedCtorInitExprClass:
     llvm_unreachable("unexpected statement kind");
-  case Expr::UniqueStableNameExprClass:
-    llvm_unreachable("unique-stable-name mangling not implemented yet");
 
   case Expr::ConstantExprClass:
     E = cast<ConstantExpr>(E)->getSubExpr();
@@ -4953,6 +4951,20 @@ recurse:
     Out << "v18co_yield";
     mangleExpression(cast<CoawaitExpr>(E)->getOperand());
     break;
+  case Expr::UniqueStableNameExprClass: {
+    const auto *USN = cast<UniqueStableNameExpr>(E);
+    NotPrimaryExpr();
+
+    TemplateArgument TA;
+    Out << "u20__unique_stable_name";
+    if (USN->isExpr()) {
+      mangleTemplateArgExpr(USN->getExpr());
+    } else {
+      mangleType(USN->getTypeSourceInfo()->getType());
+    }
+    Out << "E";
+    break;
+  }
   }
 
   if (AsTemplateArg && !IsPrimaryExpr)

--- a/clang/lib/AST/ItaniumMangle.cpp
+++ b/clang/lib/AST/ItaniumMangle.cpp
@@ -6305,9 +6305,8 @@ void ItaniumMangleContextImpl::mangleLambdaSig(const CXXRecordDecl *Lambda,
   Mangler.mangleLambdaSig(Lambda);
 }
 
-
-ItaniumMangleContext *
-ItaniumMangleContext::create(ASTContext &Context, DiagnosticsEngine &Diags) {
+ItaniumMangleContext *ItaniumMangleContext::create(ASTContext &Context,
+                                                   DiagnosticsEngine &Diags) {
   return new ItaniumMangleContextImpl(
       Context, Diags, [](ASTContext &, const TagDecl *) { return false; },
       [](ASTContext &, const TagDecl *, raw_ostream &) {});

--- a/clang/lib/AST/ItaniumMangle.cpp
+++ b/clang/lib/AST/ItaniumMangle.cpp
@@ -247,7 +247,7 @@ public:
     return Name;
   }
 
-  KernelMangleCallbackTy getKernelMangleCallback() override {
+  KernelMangleCallbackTy getKernelMangleCallback() const override {
     return KernelMangleCallback;
   }
 
@@ -4075,8 +4075,10 @@ recurse:
   case Expr::OMPArrayShapingExprClass:
   case Expr::OMPIteratorExprClass:
   case Expr::CXXInheritedCtorInitExprClass:
-  case Expr::UniqueStableNameExprClass:
     llvm_unreachable("unexpected statement kind");
+  case Expr::UniqueStableNameExprClass:
+    // TODO: ERICH: Figure out if this is possible to reach here.
+    llvm_unreachable("unique-stable-name mangling not implemented yet");
 
   case Expr::ConstantExprClass:
     E = cast<ConstantExpr>(E)->getSubExpr();

--- a/clang/lib/AST/ItaniumMangle.cpp
+++ b/clang/lib/AST/ItaniumMangle.cpp
@@ -4069,6 +4069,7 @@ recurse:
   case Expr::OMPArrayShapingExprClass:
   case Expr::OMPIteratorExprClass:
   case Expr::CXXInheritedCtorInitExprClass:
+  case Expr::UniqueStableNameExprClass:
     llvm_unreachable("unexpected statement kind");
 
   case Expr::ConstantExprClass:

--- a/clang/lib/AST/ItaniumMangle.cpp
+++ b/clang/lib/AST/ItaniumMangle.cpp
@@ -4085,7 +4085,6 @@ recurse:
   case Expr::CXXInheritedCtorInitExprClass:
     llvm_unreachable("unexpected statement kind");
   case Expr::UniqueStableNameExprClass:
-    // TODO: ERICH: Figure out if this is possible to reach here.
     llvm_unreachable("unique-stable-name mangling not implemented yet");
 
   case Expr::ConstantExprClass:

--- a/clang/lib/AST/ItaniumMangle.cpp
+++ b/clang/lib/AST/ItaniumMangle.cpp
@@ -6308,8 +6308,8 @@ void ItaniumMangleContextImpl::mangleLambdaSig(const CXXRecordDecl *Lambda,
 ItaniumMangleContext *ItaniumMangleContext::create(ASTContext &Context,
                                                    DiagnosticsEngine &Diags) {
   return new ItaniumMangleContextImpl(
-      Context, Diags, [](ASTContext &, const TagDecl *) { return false; },
-      [](ASTContext &, const TagDecl *, raw_ostream &) {});
+      Context, Diags, [](ASTContext &, const CXXRecordDecl *) { return false; },
+      [](ASTContext &, const CXXRecordDecl *, raw_ostream &) {});
 }
 
 ItaniumMangleContext *ItaniumMangleContext::create(

--- a/clang/lib/AST/JSONNodeDumper.cpp
+++ b/clang/lib/AST/JSONNodeDumper.cpp
@@ -1163,6 +1163,12 @@ void JSONNodeDumper::VisitDeclRefExpr(const DeclRefExpr *DRE) {
   }
 }
 
+void JSONNodeDumper::VisitUniqueStableNameExpr(const UniqueStableNameExpr *E) {
+  if (E->isTypeSourceInfo())
+    JOS.attribute("typeSourceInfo",
+                  createQualType(E->getTypeSourceInfo()->getType()));
+}
+
 void JSONNodeDumper::VisitPredefinedExpr(const PredefinedExpr *PE) {
   JOS.attribute("name", PredefinedExpr::getIdentKindName(PE->getIdentKind()));
 }

--- a/clang/lib/AST/StmtPrinter.cpp
+++ b/clang/lib/AST/StmtPrinter.cpp
@@ -1077,6 +1077,16 @@ void StmtPrinter::VisitObjCSubscriptRefExpr(ObjCSubscriptRefExpr *Node) {
   OS << "]";
 }
 
+void StmtPrinter::VisitUniqueStableNameExpr(UniqueStableNameExpr *Node) {
+  // FIXME: Is this the correct thing?
+  OS << "__builtin_unique_stable_name(";
+  if (Node->isExpr())
+    PrintExpr(Node->getExpr());
+  else
+    Node->getTypeSourceInfo()->getType().print(OS, Policy);
+  OS << ")";
+}
+
 void StmtPrinter::VisitPredefinedExpr(PredefinedExpr *Node) {
   OS << PredefinedExpr::getIdentKindName(Node->getIdentKind());
 }

--- a/clang/lib/AST/StmtProfile.cpp
+++ b/clang/lib/AST/StmtProfile.cpp
@@ -1191,8 +1191,6 @@ void StmtProfiler::VisitDeclRefExpr(const DeclRefExpr *S) {
 }
 
 void StmtProfiler::VisitUniqueStableNameExpr(const UniqueStableNameExpr *S) {
-  // TODO: ERICH: is this how this is supposed to work?  I'm not sure what this
-  // is doing.
   VisitExpr(S);
   ID.AddBoolean(S->isExpr());
   if (S->isExpr())
@@ -2078,7 +2076,7 @@ void StmtProfiler::VisitSizeOfPackExpr(const SizeOfPackExpr *S) {
   VisitDecl(S->getPack());
   if (S->isPartiallySubstituted()) {
     auto Args = S->getPartialArguments();
-
+    ID.AddInteger(Args.size());
     for (const auto &TA : Args)
       VisitTemplateArgument(TA);
   } else {

--- a/clang/lib/AST/StmtProfile.cpp
+++ b/clang/lib/AST/StmtProfile.cpp
@@ -1190,6 +1190,17 @@ void StmtProfiler::VisitDeclRefExpr(const DeclRefExpr *S) {
   }
 }
 
+void StmtProfiler::VisitUniqueStableNameExpr(const UniqueStableNameExpr *S) {
+  // TODO: ERICH: is this how this is supposed to work?  I'm not sure what this
+  // is doing.
+  VisitExpr(S);
+  ID.AddBoolean(S->isExpr());
+  if (S->isExpr())
+    VisitStmt(S->getExpr());
+  else
+    VisitType(S->getTypeSourceInfo()->getType());
+}
+
 void StmtProfiler::VisitPredefinedExpr(const PredefinedExpr *S) {
   VisitExpr(S);
   ID.AddInteger(S->getIdentKind());
@@ -2067,7 +2078,7 @@ void StmtProfiler::VisitSizeOfPackExpr(const SizeOfPackExpr *S) {
   VisitDecl(S->getPack());
   if (S->isPartiallySubstituted()) {
     auto Args = S->getPartialArguments();
-    ID.AddInteger(Args.size());
+
     for (const auto &TA : Args)
       VisitTemplateArgument(TA);
   } else {

--- a/clang/lib/AST/TextNodeDumper.cpp
+++ b/clang/lib/AST/TextNodeDumper.cpp
@@ -1016,6 +1016,12 @@ void TextNodeDumper::VisitObjCIvarRefExpr(const ObjCIvarRefExpr *Node) {
     OS << " isFreeIvar";
 }
 
+void TextNodeDumper::VisitUniqueStableNameExpr(
+    const UniqueStableNameExpr *Node) {
+  if (Node->isTypeSourceInfo())
+    dumpType(Node->getTypeSourceInfo()->getType());
+}
+
 void TextNodeDumper::VisitPredefinedExpr(const PredefinedExpr *Node) {
   OS << " " << PredefinedExpr::getIdentKindName(Node->getIdentKind());
 }

--- a/clang/lib/CodeGen/CGExprScalar.cpp
+++ b/clang/lib/CodeGen/CGExprScalar.cpp
@@ -1589,10 +1589,7 @@ Value *ScalarExprEmitter::VisitExpr(Expr *E) {
 
 Value *ScalarExprEmitter::VisitUniqueStableNameExpr(UniqueStableNameExpr *E) {
   ASTContext &Context = CGF.getContext();
-  llvm::Constant *Str = Builder.CreateGlobalStringPtr(
-      E->ComputeName(Context), "usn_str");
-  Address GVAddr = Address(Str, Context.getTypeAlignInChars(E->getType()));
-  return Builder.CreateLoad(GVAddr, llvm::Twine{"usn_str_load"});
+  return Builder.CreateGlobalStringPtr(E->ComputeName(Context), "usn_str");
 }
 
 Value *ScalarExprEmitter::VisitShuffleVectorExpr(ShuffleVectorExpr *E) {

--- a/clang/lib/CodeGen/CGExprScalar.cpp
+++ b/clang/lib/CodeGen/CGExprScalar.cpp
@@ -1588,17 +1588,9 @@ Value *ScalarExprEmitter::VisitExpr(Expr *E) {
 }
 
 Value *ScalarExprEmitter::VisitUniqueStableNameExpr(UniqueStableNameExpr *E) {
-  auto Callback = []() { /*TODO ERICH: Implement*/ };
   ASTContext &Context = CGF.getContext();
-  std::unique_ptr<MangleContext> Ctx{ItaniumMangleContext::create(
-      Context, Context.getDiagnostics(), Callback)};
-
-  QualType Ty = E->getTypeSourceInfo()->getType();
-  SmallString<256> Buffer;
-  llvm::raw_svector_ostream Out(Buffer);
-  Ctx->mangleTypeName(Ty, Out);
-
-  llvm::Constant *Str = Builder.CreateGlobalStringPtr(Buffer, "usn_str");
+  llvm::Constant *Str = Builder.CreateGlobalStringPtr(
+      E->ComputeName(Context), "usn_str");
   Address GVAddr = Address(Str, Context.getTypeAlignInChars(E->getType()));
   return Builder.CreateLoad(GVAddr, llvm::Twine{"usn_str_load"});
 }

--- a/clang/lib/Parse/ParseExpr.cpp
+++ b/clang/lib/Parse/ParseExpr.cpp
@@ -2341,11 +2341,6 @@ ExprResult Parser::ParseUniqueStableNameExpression() {
                          "__builtin_unique_stable_name"))
     return ExprError();
 
-  // TODO: ERICH: Does moving this above hte isTypeIdInParens avoid the issue of
-  // evaluating a VLA?
-  EnterExpressionEvaluationContext Unevaluated(
-      Actions, Sema::ExpressionEvaluationContext::Unevaluated);
-
   if (isTypeIdInParens()) {
     TypeResult Ty = ParseTypeName();
     T.consumeClose();
@@ -2357,6 +2352,8 @@ ExprResult Parser::ParseUniqueStableNameExpression() {
                                              T.getCloseLocation(), Ty.get());
   }
 
+  EnterExpressionEvaluationContext Unevaluated(
+      Actions, Sema::ExpressionEvaluationContext::Unevaluated);
   ExprResult Result = ParseExpression();
 
   if (Result.isInvalid()) {

--- a/clang/lib/Parse/ParseExpr.cpp
+++ b/clang/lib/Parse/ParseExpr.cpp
@@ -1469,6 +1469,9 @@ ExprResult Parser::ParseCastExpression(CastParseKind ParseKind,
   case tok::kw_this:
     Res = ParseCXXThis();
     break;
+  case tok::kw___builtin_unique_stable_name:
+    Res = ParseUniqueStableNameExpression();
+    break;
 
   case tok::annot_typename:
     if (isStartOfObjCClassMessageMissingOpenBracket()) {
@@ -2322,6 +2325,45 @@ Parser::ParseExprAfterUnaryExprOrTypeTrait(const Token &OpTok,
   // If we get here, the operand to the typeof/sizeof/alignof was an expression.
   isCastExpr = false;
   return Operand;
+}
+
+/// Parse a __builtin_unique_stable_name expression.  Accepts a type-id or an
+/// arbitrary expression as a parameter.
+ExprResult Parser::ParseUniqueStableNameExpression() {
+  assert(Tok.is(tok::kw___builtin_unique_stable_name) &&
+         "Not __bulitin_unique_stable_name");
+
+  SourceLocation OpLoc = ConsumeToken();
+  BalancedDelimiterTracker T(*this, tok::l_paren);
+
+  // typeid expressions are always parenthesized.
+  if (T.expectAndConsume(diag::err_expected_lparen_after,
+                         "__builtin_unique_stable_name"))
+    return ExprError();
+
+  if (isTypeIdInParens()) {
+    TypeResult Ty = ParseTypeName();
+    T.consumeClose();
+
+    if (Ty.isInvalid())
+      return ExprError();
+
+    return Actions.ActOnUniqueStableNameExpr(OpLoc, T.getOpenLocation(),
+                                             T.getCloseLocation(), Ty.get());
+  }
+
+  EnterExpressionEvaluationContext Unevaluated(
+      Actions, Sema::ExpressionEvaluationContext::Unevaluated);
+  ExprResult Result = ParseExpression();
+
+  if (Result.isInvalid()) {
+    SkipUntil(tok::r_paren, StopAtSemi);
+    return Result;
+  }
+
+  T.consumeClose();
+  return Actions.ActOnUniqueStableNameExpr(OpLoc, T.getOpenLocation(),
+                                           T.getCloseLocation(), Result.get());
 }
 
 

--- a/clang/lib/Parse/ParseExpr.cpp
+++ b/clang/lib/Parse/ParseExpr.cpp
@@ -2336,10 +2336,15 @@ ExprResult Parser::ParseUniqueStableNameExpression() {
   SourceLocation OpLoc = ConsumeToken();
   BalancedDelimiterTracker T(*this, tok::l_paren);
 
-  // typeid expressions are always parenthesized.
+  // __builtin_unique_stable_name expressions are always parenthesized.
   if (T.expectAndConsume(diag::err_expected_lparen_after,
                          "__builtin_unique_stable_name"))
     return ExprError();
+
+  // TODO: ERICH: Does moving this above hte isTypeIdInParens avoid the issue of
+  // evaluating a VLA?
+  EnterExpressionEvaluationContext Unevaluated(
+      Actions, Sema::ExpressionEvaluationContext::Unevaluated);
 
   if (isTypeIdInParens()) {
     TypeResult Ty = ParseTypeName();
@@ -2352,8 +2357,6 @@ ExprResult Parser::ParseUniqueStableNameExpression() {
                                              T.getCloseLocation(), Ty.get());
   }
 
-  EnterExpressionEvaluationContext Unevaluated(
-      Actions, Sema::ExpressionEvaluationContext::Unevaluated);
   ExprResult Result = ParseExpression();
 
   if (Result.isInvalid()) {

--- a/clang/lib/Parse/ParseExpr.cpp
+++ b/clang/lib/Parse/ParseExpr.cpp
@@ -2366,7 +2366,6 @@ ExprResult Parser::ParseUniqueStableNameExpression() {
                                            T.getCloseLocation(), Result.get());
 }
 
-
 /// Parse a sizeof or alignof expression.
 ///
 /// \verbatim

--- a/clang/lib/Sema/SemaExceptionSpec.cpp
+++ b/clang/lib/Sema/SemaExceptionSpec.cpp
@@ -1573,6 +1573,8 @@ CanThrowResult Sema::canThrow(const Stmt *S) {
     return mergeCanThrow(CT, canThrow(TS->getTryBody()));
   }
 
+  case Stmt::UniqueStableNameExprClass:
+    return CT_Cannot;
   case Stmt::NoStmtClass:
     llvm_unreachable("Invalid class for statement");
   }

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -3497,6 +3497,11 @@ ExprResult Sema::BuildUniqueStableNameExpr(SourceLocation OpLoc,
                                            SourceLocation LParen,
                                            SourceLocation RParen,
                                            TypeSourceInfo *TSI) {
+  if (RequireCompleteSizedType(
+          OpLoc, TSI->getType(),
+          diag::err_sizeof_alignof_incomplete_or_sizeless_type,
+          "__builtin_unique_stable_name", SourceRange{LParen, RParen}))
+    return ExprError();
   return UniqueStableNameExpr::Create(Context, OpLoc, LParen, RParen, TSI);
 }
 ExprResult Sema::BuildUniqueStableNameExpr(SourceLocation OpLoc,
@@ -3507,9 +3512,8 @@ ExprResult Sema::BuildUniqueStableNameExpr(SourceLocation OpLoc,
   if (E->isInstantiationDependent())
     return UniqueStableNameExpr::Create(Context, OpLoc, LParen, RParen, E);
 
-  return UniqueStableNameExpr::Create(
-      Context, OpLoc, LParen, RParen,
-      Context.getTrivialTypeSourceInfo(E->getType()));
+  return BuildUniqueStableNameExpr(
+      OpLoc, LParen, RParen, Context.getTrivialTypeSourceInfo(E->getType()));
 }
 
 ExprResult Sema::ActOnUniqueStableNameExpr(SourceLocation OpLoc,

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -3493,6 +3493,47 @@ ExprResult Sema::BuildPredefinedExpr(SourceLocation Loc,
   return PredefinedExpr::Create(Context, Loc, ResTy, IK, SL);
 }
 
+ExprResult Sema::BuildUniqueStableNameExpr(SourceLocation OpLoc,
+                                           SourceLocation LParen,
+                                           SourceLocation RParen,
+                                           TypeSourceInfo *TSI) {
+  return UniqueStableNameExpr::Create(Context, OpLoc, LParen, RParen, TSI);
+}
+ExprResult Sema::BuildUniqueStableNameExpr(SourceLocation OpLoc,
+                                           SourceLocation LParen,
+                                           SourceLocation RParen, Expr *E) {
+  // If this isn't dependent anymore, we know the type, so convert to a Type
+  // based version of the UniqueStableNameExpr.
+  if (E->isInstantiationDependent())
+    return UniqueStableNameExpr::Create(Context, OpLoc, LParen, RParen, E);
+
+  return UniqueStableNameExpr::Create(
+      Context, OpLoc, LParen, RParen,
+      Context.getTrivialTypeSourceInfo(E->getType()));
+}
+
+ExprResult Sema::ActOnUniqueStableNameExpr(SourceLocation OpLoc,
+                                           SourceLocation LParen,
+                                           SourceLocation RParen,
+                                           ParsedType ParsedTy) {
+  TypeSourceInfo *TSI = nullptr;
+  QualType Ty = GetTypeFromParser(ParsedTy, &TSI);
+
+  if (Ty.isNull())
+    return ExprError();
+  if (!TSI)
+    TSI = Context.getTrivialTypeSourceInfo(Ty, LParen);
+
+  return BuildUniqueStableNameExpr(OpLoc, LParen, RParen, TSI);
+}
+
+ExprResult Sema::ActOnUniqueStableNameExpr(SourceLocation OpLoc,
+                                           SourceLocation LParen,
+                                           SourceLocation RParen,
+                                           Expr *Operand) {
+  return BuildUniqueStableNameExpr(OpLoc, LParen, RParen, Operand);
+}
+
 ExprResult Sema::ActOnPredefinedExpr(SourceLocation Loc, tok::TokenKind Kind) {
   PredefinedExpr::IdentKind IK;
 

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -3497,11 +3497,6 @@ ExprResult Sema::BuildUniqueStableNameExpr(SourceLocation OpLoc,
                                            SourceLocation LParen,
                                            SourceLocation RParen,
                                            TypeSourceInfo *TSI) {
-  //if (RequireCompleteSizedType(
-  //        OpLoc, TSI->getType(),
-  //        diag::err_sizeof_alignof_incomplete_or_sizeless_type,
-  //        "__builtin_unique_stable_name", SourceRange{LParen, RParen}))
-  //  return ExprError();
   return UniqueStableNameExpr::Create(Context, OpLoc, LParen, RParen, TSI);
 }
 ExprResult Sema::BuildUniqueStableNameExpr(SourceLocation OpLoc,

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -3497,11 +3497,11 @@ ExprResult Sema::BuildUniqueStableNameExpr(SourceLocation OpLoc,
                                            SourceLocation LParen,
                                            SourceLocation RParen,
                                            TypeSourceInfo *TSI) {
-  if (RequireCompleteSizedType(
-          OpLoc, TSI->getType(),
-          diag::err_sizeof_alignof_incomplete_or_sizeless_type,
-          "__builtin_unique_stable_name", SourceRange{LParen, RParen}))
-    return ExprError();
+  //if (RequireCompleteSizedType(
+  //        OpLoc, TSI->getType(),
+  //        diag::err_sizeof_alignof_incomplete_or_sizeless_type,
+  //        "__builtin_unique_stable_name", SourceRange{LParen, RParen}))
+  //  return ExprError();
   return UniqueStableNameExpr::Create(Context, OpLoc, LParen, RParen, TSI);
 }
 ExprResult Sema::BuildUniqueStableNameExpr(SourceLocation OpLoc,

--- a/clang/lib/Sema/SemaLambda.cpp
+++ b/clang/lib/Sema/SemaLambda.cpp
@@ -461,11 +461,15 @@ void Sema::handleLambdaNumbering(
   std::tie(MCtx, ManglingContextDecl) =
       getCurrentMangleNumberContext(Class->getDeclContext());
   bool HasKnownInternalLinkage = false;
-  if (!MCtx && getLangOpts().CUDA) {
+  if (!MCtx && (getLangOpts().CUDA || getLangOpts().SYCLIsDevice ||
+                getLangOpts().SYCLIsHost)) {
     // Force lambda numbering in CUDA/HIP as we need to name lambdas following
     // ODR. Both device- and host-compilation need to have a consistent naming
     // on kernel functions. As lambdas are potential part of these `__global__`
     // function names, they needs numbering following ODR.
+    // Also force for SYCL, since we need this for the
+    // __builtin_unique_stable_name implementation, which depends on lambda
+    // mangling.
     MCtx = getMangleNumberingContext(Class, ManglingContextDecl);
     assert(MCtx && "Retrieving mangle numbering context failed!");
     HasKnownInternalLinkage = true;

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -77,5 +77,4 @@ void Sema::AddSYCLKernelLambda(const FunctionDecl *FD) {
       Context, Context.getDiagnostics(), ShouldMangleCallback, MangleCallback)};
   llvm::raw_null_ostream Out;
   Ctx->mangleTypeName(Ty, Out);
-  (void)FD;
 }

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -68,6 +68,7 @@ GetSYCLKernelObjectDecl(const FunctionDecl *KernelCaller) {
 void Sema::AddSYCLKernelLambda(const FunctionDecl *FD) {
   auto Callback = [](ASTContext &Ctx, const TagDecl *TD, raw_ostream &) {
     Ctx.AddSYCLKernelNamingDecl(TD);
+    return false;
   };
 
   // TODO: ERICH: get the kernel object type here.

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -8,6 +8,7 @@
 // This implements Semantic Analysis for SYCL constructs.
 //===----------------------------------------------------------------------===//
 
+#include "clang/AST/Mangle.h"
 #include "clang/Sema/Sema.h"
 #include "clang/Sema/SemaDiagnostic.h"
 
@@ -46,4 +47,17 @@ bool Sema::checkSYCLDeviceFunction(SourceLocation Loc, FunctionDecl *Callee) {
 
   return DiagKind != SemaDiagnosticBuilder::K_Immediate &&
          DiagKind != SemaDiagnosticBuilder::K_ImmediateWithCallStack;
+}
+
+void Sema::AddSYCLKernelLambda(const FunctionDecl *FD) {
+  auto Callback = [](){/*TODO ERICH: Implement*/};
+
+  // TODO: ERICH: get the kernel object type here.
+  // getKernelObjectType
+  QualType Ty;
+  std::unique_ptr<MangleContext> Ctx{ItaniumMangleContext::create(
+      Context, Context.getDiagnostics(), Callback)};
+  llvm::raw_null_ostream Out;
+  Ctx->mangleTypeName(Ty, Out);
+  (void)FD;
 }

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -65,13 +65,12 @@ static QualType GetSYCLKernelObjectType(const FunctionDecl *KernelCaller) {
 }
 
 void Sema::AddSYCLKernelLambda(const FunctionDecl *FD) {
-  auto ShouldMangleCallback = [](ASTContext &Ctx, const TagDecl *TD) {
+  auto ShouldMangleCallback = [](ASTContext &Ctx, const CXXRecordDecl *RD) {
     // We ALWAYS want to descend into the lambda mangling for these.
     return true;
   };
-  auto MangleCallback = [](ASTContext &Ctx, const TagDecl *TD, raw_ostream &) {
-    Ctx.AddSYCLKernelNamingDecl(TD);
-  };
+  auto MangleCallback = [](ASTContext &Ctx, const CXXRecordDecl *RD,
+                           raw_ostream &) { Ctx.AddSYCLKernelNamingDecl(RD); };
 
   QualType Ty = GetSYCLKernelObjectType(FD);
   std::unique_ptr<MangleContext> Ctx{ItaniumMangleContext::create(

--- a/clang/lib/Sema/SemaTemplateInstantiate.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiate.cpp
@@ -1076,6 +1076,7 @@ namespace {
 
     const LoopHintAttr *TransformLoopHintAttr(const LoopHintAttr *LH);
 
+    ExprResult TransformUniqueStableNameExpr(UniqueStableNameExpr *E);
     ExprResult TransformPredefinedExpr(PredefinedExpr *E);
     ExprResult TransformDeclRefExpr(DeclRefExpr *E);
     ExprResult TransformCXXDefaultArgExpr(CXXDefaultArgExpr *E);
@@ -1417,6 +1418,19 @@ TemplateName TemplateInstantiator::TransformTemplateName(
   return inherited::TransformTemplateName(SS, Name, NameLoc, ObjectType,
                                           FirstQualifierInScope,
                                           AllowInjectedClassName);
+}
+
+ExprResult
+TemplateInstantiator::TransformUniqueStableNameExpr(UniqueStableNameExpr *E) {
+  // Build automatically changes to the non-dependent version in the 'Expr'
+  // overload.
+  if (E->isExpr())
+    return getSema().BuildUniqueStableNameExpr(
+        E->getLocation(), E->getLParenLocation(), E->getRParenLocation(),
+        E->getExpr());
+  return getSema().BuildUniqueStableNameExpr(
+      E->getLocation(), E->getLParenLocation(), E->getRParenLocation(),
+      E->getTypeSourceInfo());
 }
 
 ExprResult

--- a/clang/lib/Sema/SemaTemplateInstantiate.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiate.cpp
@@ -1076,7 +1076,6 @@ namespace {
 
     const LoopHintAttr *TransformLoopHintAttr(const LoopHintAttr *LH);
 
-    ExprResult TransformUniqueStableNameExpr(UniqueStableNameExpr *E);
     ExprResult TransformPredefinedExpr(PredefinedExpr *E);
     ExprResult TransformDeclRefExpr(DeclRefExpr *E);
     ExprResult TransformCXXDefaultArgExpr(CXXDefaultArgExpr *E);
@@ -1418,19 +1417,6 @@ TemplateName TemplateInstantiator::TransformTemplateName(
   return inherited::TransformTemplateName(SS, Name, NameLoc, ObjectType,
                                           FirstQualifierInScope,
                                           AllowInjectedClassName);
-}
-
-ExprResult
-TemplateInstantiator::TransformUniqueStableNameExpr(UniqueStableNameExpr *E) {
-  // Build automatically changes to the non-dependent version in the 'Expr'
-  // overload.
-  if (E->isExpr())
-    return getSema().BuildUniqueStableNameExpr(
-        E->getLocation(), E->getLParenLocation(), E->getRParenLocation(),
-        E->getExpr());
-  return getSema().BuildUniqueStableNameExpr(
-      E->getLocation(), E->getLParenLocation(), E->getRParenLocation(),
-      E->getTypeSourceInfo());
 }
 
 ExprResult

--- a/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
@@ -571,7 +571,6 @@ static void instantiateDependentSYCLKernelAttr(
              diag::note_unique_stable_name_evaluated_here);
       // Update this so future diagnostics work correctly.
       Itr.second = CurName;
-      return;
     }
   }
 

--- a/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
@@ -548,6 +548,28 @@ static void instantiateDependentAMDGPUWavesPerEUAttr(
   S.addAMDGPUWavesPerEUAttr(New, Attr, MinExpr, MaxExpr);
 }
 
+// This doesn't take any template parameters, but we have a custom action that
+// needs to happen when the kernel itself is instantiated. We need to run the
+// ItaniumMangler to mark the names required to name this kernel.
+static void instantiateDependentSYCLKernelAttr(
+    Sema &S, const MultiLevelTemplateArgumentList &TemplateArgs,
+    const SYCLKernelAttr &Attr, Decl *New) {
+  const auto *FD = cast<FunctionDecl>(New);
+  (void)FD;
+
+  // Functions cannot be partially specialized, so if we are being instantiated,
+  // we are obviously a complete specialization. Since this attribute is only
+  // valid on function template declarations, we know that this is a full
+  // instantiation of a kernel.
+
+  // TODO: ERICH: get the kernel object type here.
+  // getKernelObjectType
+  // TODO: ERICH: run the itanium mangler with a null-target and a callback that
+  // will save the lambdas we visit.
+  // TODO: ERICH: see the PredefinedExpr::ComputeName for an example.
+  New->addAttr(Attr.clone(S.getASTContext()));
+}
+
 /// Determine whether the attribute A might be relevent to the declaration D.
 /// If not, we can skip instantiating it. The attribute may or may not have
 /// been instantiated yet.
@@ -720,6 +742,11 @@ void Sema::InstantiateAttrs(const MultiLevelTemplateArgumentList &TemplateArgs,
     if (auto *A = dyn_cast<OwnerAttr>(TmplAttr)) {
       if (!New->hasAttr<OwnerAttr>())
         New->addAttr(A->clone(Context));
+      continue;
+    }
+
+    if (auto *A = dyn_cast<SYCLKernelAttr>(TmplAttr)) {
+      instantiateDependentSYCLKernelAttr(*this, TemplateArgs, *A, New);
       continue;
     }
 

--- a/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
@@ -554,19 +554,12 @@ static void instantiateDependentAMDGPUWavesPerEUAttr(
 static void instantiateDependentSYCLKernelAttr(
     Sema &S, const MultiLevelTemplateArgumentList &TemplateArgs,
     const SYCLKernelAttr &Attr, Decl *New) {
-  const auto *FD = cast<FunctionDecl>(New);
-  (void)FD;
-
   // Functions cannot be partially specialized, so if we are being instantiated,
   // we are obviously a complete specialization. Since this attribute is only
   // valid on function template declarations, we know that this is a full
   // instantiation of a kernel.
+  S.AddSYCLKernelLambda(cast<FunctionDecl>(New));
 
-  // TODO: ERICH: get the kernel object type here.
-  // getKernelObjectType
-  // TODO: ERICH: run the itanium mangler with a null-target and a callback that
-  // will save the lambdas we visit.
-  // TODO: ERICH: see the PredefinedExpr::ComputeName for an example.
   New->addAttr(Attr.clone(S.getASTContext()));
 }
 

--- a/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
@@ -554,20 +554,23 @@ static void instantiateDependentAMDGPUWavesPerEUAttr(
 static void instantiateDependentSYCLKernelAttr(
     Sema &S, const MultiLevelTemplateArgumentList &TemplateArgs,
     const SYCLKernelAttr &Attr, Decl *New) {
-
-  // Diagnose if we have already constant-evaluated one of these builtins.
-  if (S.Context.KernelNameEvaluatedFirst.isValid()) {
-    S.Diag(S.Context.KernelNameEvaluatedFirst,
-           diag::err_unique_stable_name_already_evaluated);
-    S.Diag(New->getLocation(), diag::note_kernel_instantiated_here);
-    return;
-  }
-
   // Functions cannot be partially specialized, so if we are being instantiated,
   // we are obviously a complete specialization. Since this attribute is only
   // valid on function template declarations, we know that this is a full
   // instantiation of a kernel.
   S.AddSYCLKernelLambda(cast<FunctionDecl>(New));
+
+  // Evaluate whether this would change any of the already evaluated
+  // __builtin_unique_stable_name values.
+  for (const auto Itr : S.Context.UniqueStableNameEvaluatedValues) {
+    if (Itr.second != Itr.first->ComputeName(S.Context)) {
+      S.Diag(New->getLocation(),
+             diag::err_kernel_invalidates_unique_stable_name);
+      S.Diag(Itr.first->getLocation(),
+             diag::note_unique_stable_name_evaluated_here);
+      return;
+    }
+  }
 
   New->addAttr(Attr.clone(S.getASTContext()));
 }

--- a/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
@@ -562,12 +562,15 @@ static void instantiateDependentSYCLKernelAttr(
 
   // Evaluate whether this would change any of the already evaluated
   // __builtin_unique_stable_name values.
-  for (const auto Itr : S.Context.UniqueStableNameEvaluatedValues) {
-    if (Itr.second != Itr.first->ComputeName(S.Context)) {
+  for (auto &Itr : S.Context.UniqueStableNameEvaluatedValues) {
+    const std::string &CurName = Itr.first->ComputeName(S.Context);
+    if (Itr.second != CurName) {
       S.Diag(New->getLocation(),
              diag::err_kernel_invalidates_unique_stable_name);
       S.Diag(Itr.first->getLocation(),
              diag::note_unique_stable_name_evaluated_here);
+      // Update this so future diagnostics work correctly.
+      Itr.second = CurName;
       return;
     }
   }

--- a/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
@@ -554,6 +554,15 @@ static void instantiateDependentAMDGPUWavesPerEUAttr(
 static void instantiateDependentSYCLKernelAttr(
     Sema &S, const MultiLevelTemplateArgumentList &TemplateArgs,
     const SYCLKernelAttr &Attr, Decl *New) {
+
+  // Diagnose if we have already constant-evaluated one of these builtins.
+  if (S.Context.KernelNameEvaluatedFirst.isValid()) {
+    S.Diag(S.Context.KernelNameEvaluatedFirst,
+           diag::err_unique_stable_name_already_evaluated);
+    S.Diag(New->getLocation(), diag::note_kernel_instantiated_here);
+    return;
+  }
+
   // Functions cannot be partially specialized, so if we are being instantiated,
   // we are obviously a complete specialization. Since this attribute is only
   // valid on function template declarations, we know that this is a full

--- a/clang/lib/Sema/TreeTransform.h
+++ b/clang/lib/Sema/TreeTransform.h
@@ -10202,6 +10202,11 @@ TreeTransform<Derived>::TransformUniqueStableNameExpr(UniqueStableNameExpr *E) {
     if (ER.isInvalid())
       return ExprError();
 
+    ER = getSema().CheckPlaceholderExpr(ER.get());
+
+    if (ER.isInvalid())
+      return ExprError();
+
     if (!getDerived().AlwaysRebuild() && E->getExpr() == ER.get())
       return E;
 

--- a/clang/lib/Sema/TreeTransform.h
+++ b/clang/lib/Sema/TreeTransform.h
@@ -10195,8 +10195,7 @@ ExprResult
 TreeTransform<Derived>::TransformUniqueStableNameExpr(UniqueStableNameExpr *E) {
   if (!E->isTypeDependent())
     return E;
-  // We only have to handle the 'Expr' case, since the type case cannot be
-  // dependent.
+
   if (E->isExpr()) {
     ExprResult ER = getDerived().TransformExpr(E->getExpr());
 

--- a/clang/lib/Sema/TreeTransform.h
+++ b/clang/lib/Sema/TreeTransform.h
@@ -2399,6 +2399,19 @@ public:
     return SEHFinallyStmt::Create(getSema().getASTContext(), Loc, Block);
   }
 
+  ExprResult RebuildUniqueStableNameExpr(SourceLocation OpLoc,
+                                         SourceLocation LParen,
+                                         SourceLocation RParen, Expr *E) {
+    return getSema().BuildUniqueStableNameExpr(OpLoc, LParen, RParen, E);
+  }
+
+  ExprResult RebuildUniqueStableNameExpr(SourceLocation OpLoc,
+                                         SourceLocation LParen,
+                                         SourceLocation RParen,
+                                         TypeSourceInfo *TSI) {
+    return getSema().BuildUniqueStableNameExpr(OpLoc, LParen, RParen, TSI);
+  }
+
   /// Build a new predefined expression.
   ///
   /// By default, performs semantic analysis to build the new expression.
@@ -10175,6 +10188,39 @@ template<typename Derived>
 ExprResult
 TreeTransform<Derived>::TransformConstantExpr(ConstantExpr *E) {
   return TransformExpr(E->getSubExpr());
+}
+
+template <typename Derived>
+ExprResult
+TreeTransform<Derived>::TransformUniqueStableNameExpr(UniqueStableNameExpr *E) {
+  if (!E->isTypeDependent())
+    return E;
+  // We only have to handle the 'Expr' case, since the type case cannot be
+  // dependent.
+  if (E->isExpr()) {
+    ExprResult ER = getDerived().TransformExpr(E->getExpr());
+
+    if (ER.isInvalid())
+      return ExprError();
+
+    if (!getDerived().AlwaysRebuild() && E->getExpr() == ER.get())
+      return E;
+
+    return getDerived().RebuildUniqueStableNameExpr(
+        E->getLocation(), E->getLParenLocation(), E->getRParenLocation(),
+        ER.get());
+  }
+
+  TypeSourceInfo *NewT = getDerived().TransformType(E->getTypeSourceInfo());
+
+  if (!NewT)
+    return ExprError();
+
+  if (!getDerived().AlwaysRebuild() && E->getTypeSourceInfo() == NewT)
+    return E;
+
+  return getDerived().RebuildUniqueStableNameExpr(
+      E->getLocation(), E->getLParenLocation(), E->getRParenLocation(), NewT);
 }
 
 template<typename Derived>

--- a/clang/lib/Serialization/ASTWriterStmt.cpp
+++ b/clang/lib/Serialization/ASTWriterStmt.cpp
@@ -579,6 +579,22 @@ void ASTStmtWriter::VisitConstantExpr(ConstantExpr *E) {
   Code = serialization::EXPR_CONSTANT;
 }
 
+void ASTStmtWriter::VisitUniqueStableNameExpr(UniqueStableNameExpr *E) {
+  VisitExpr(E);
+
+  Record.writeBool(E->isExpr());
+  Record.AddSourceLocation(E->getLocation());
+  Record.AddSourceLocation(E->getLParenLocation());
+  Record.AddSourceLocation(E->getRParenLocation());
+
+  if (E->isExpr())
+    Record.AddStmt(E->getExpr());
+  else
+    Record.AddTypeSourceInfo(E->getTypeSourceInfo());
+
+  Code = serialization::EXPR_UNIQUESTABLENAME;
+}
+
 void ASTStmtWriter::VisitPredefinedExpr(PredefinedExpr *E) {
   VisitExpr(E);
 

--- a/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
@@ -1419,6 +1419,7 @@ void ExprEngine::Visit(const Stmt *S, ExplodedNode *Pred,
     case Stmt::OMPArraySectionExprClass:
     case Stmt::OMPArrayShapingExprClass:
     case Stmt::OMPIteratorExprClass:
+    case Stmt::UniqueStableNameExprClass:
     case Stmt::TypeTraitExprClass: {
       Bldr.takeNodes(Pred);
       ExplodedNodeSet preVisit;

--- a/clang/test/CodeGenSYCL/unique_stable_name.cpp
+++ b/clang/test/CodeGenSYCL/unique_stable_name.cpp
@@ -1,33 +1,22 @@
 // RUN: %clang_cc1 -triple spir64-unknown-unknown-sycldevice -fsycl-is-device -disable-llvm-passes -emit-llvm %s -o - | FileCheck %s
-// CHECK: @[[LAMBDA_KERNEL3:[^\w]+]] = private unnamed_addr constant [[LAMBDA_K3_SIZE:\[[0-9]+ x i8\]]] c"_ZTSZ4mainEUlPZ4mainEUlvE10002_E10001_\00"
+// CHECK: @[[LAMBDA_KERNEL3:[^\w]+]] = private unnamed_addr constant [[LAMBDA_K3_SIZE:\[[0-9]+ x i8\]]] c"_ZTSZ4mainEUlPZ4mainEUlvE10000_E10000_\00"
 // CHECK: @[[INT1:[^\w]+]] = private unnamed_addr constant [[INT1_SIZE:\[[0-9]+ x i8\]]] c"_ZTSi\00"
 // CHECK: @[[STRING:[^\w]+]] = private unnamed_addr constant [[STRING_SIZE:\[[0-9]+ x i8\]]] c"_ZTSAppL_ZZ4mainE1jE_i\00",
 // CHECK: @[[INT:[^\w]+]] = private unnamed_addr constant [[INT_SIZE:\[[0-9]+ x i8\]]] c"_ZTSi\00"
-// CHECK: @[[LAMBDA_X:[^\w]+]] = private unnamed_addr constant [[LAMBDA_X_SIZE:\[[0-9]+ x i8\]]] c"_ZTSZZ4mainENKUlvE10000_clEvEUlvE_\00"
-// CHECK: @[[LAMBDA_Y:[^\w]+]] = private unnamed_addr constant [[LAMBDA_Y_SIZE:\[[0-9]+ x i8\]]] c"_ZTSZZ4mainENKUlvE10000_clEvEUlvE_\00"
-// CHECK: @[[MACRO_X:[^\w]+]] = private unnamed_addr constant [[MACRO_SIZE:\[[0-9]+ x i8\]]] c"_ZTSZZ4mainENKUlvE10000_clEvEUlvE0_\00"
-// CHECK: @[[MACRO_Y:[^\w]+]] =  private unnamed_addr constant [[MACRO_SIZE]] c"_ZTSZZ4mainENKUlvE10000_clEvEUlvE1_\00"
-// CHECK: @usn_str.8 = private unnamed_addr constant [36 x i8] c"_ZTSZZ4mainENKUlvE10000_clEvEUlvE2_\00", align 1
-// CHECK: @usn_str.9 = private unnamed_addr constant [36 x i8] c"_ZTSZZ4mainENKUlvE10000_clEvEUlvE3_\00", align 1
-// CHECK: @[[MACRO_MACRO_X:[^\w]+]] = private unnamed_addr constant [[MACRO_MACRO_SIZE:\[[0-9]+ x i8\]]] c"_ZTSZZ4mainENKUlvE10000_clEvEUlvE4_\00"
-// CHECK: @[[MACRO_MACRO_Y:[^\w]+]] = private unnamed_addr constant [[MACRO_MACRO_SIZE]] c"_ZTSZZ4mainENKUlvE10000_clEvEUlvE5_\00"
-// CHECK: @[[LAMBDA:[^\w]+]] = private unnamed_addr constant [[LAMBDA_SIZE:\[[0-9]+ x i8\]]] c"_ZTSZZ4mainENKUlvE10000_clEvEUlvE_\00"
+// CHECK: @[[LAMBDA_X:[^\w]+]] = private unnamed_addr constant [[LAMBDA_X_SIZE:\[[0-9]+ x i8\]]] c"_ZTSZZ4mainENKUlvE10001_clEvEUlvE_\00"
+// CHECK: @[[LAMBDA_Y:[^\w]+]] = private unnamed_addr constant [[LAMBDA_Y_SIZE:\[[0-9]+ x i8\]]] c"_ZTSZZ4mainENKUlvE10001_clEvEUlvE_\00"
+// CHECK: @[[MACRO_X:[^\w]+]] = private unnamed_addr constant [[MACRO_SIZE:\[[0-9]+ x i8\]]] c"_ZTSZZ4mainENKUlvE10001_clEvEUlvE0_\00"
+// CHECK: @[[MACRO_Y:[^\w]+]] =  private unnamed_addr constant [[MACRO_SIZE]] c"_ZTSZZ4mainENKUlvE10001_clEvEUlvE1_\00"
+// CHECK: @usn_str.8 = private unnamed_addr constant [36 x i8] c"_ZTSZZ4mainENKUlvE10001_clEvEUlvE2_\00", align 1
+// CHECK: @usn_str.9 = private unnamed_addr constant [36 x i8] c"_ZTSZZ4mainENKUlvE10001_clEvEUlvE3_\00", align 1
+// CHECK: @[[MACRO_MACRO_X:[^\w]+]] = private unnamed_addr constant [[MACRO_MACRO_SIZE:\[[0-9]+ x i8\]]] c"_ZTSZZ4mainENKUlvE10001_clEvEUlvE4_\00"
+// CHECK: @[[MACRO_MACRO_Y:[^\w]+]] = private unnamed_addr constant [[MACRO_MACRO_SIZE]] c"_ZTSZZ4mainENKUlvE10001_clEvEUlvE5_\00"
+// CHECK: @[[LAMBDA:[^\w]+]] = private unnamed_addr constant [[LAMBDA_SIZE:\[[0-9]+ x i8\]]] c"_ZTSZZ4mainENKUlvE10001_clEvEUlvE_\00"
 // CHECK: @[[LAMBDA_IN_DEP_INT:[^\w]+]] = private unnamed_addr constant [[DEP_INT_SIZE:\[[0-9]+ x i8\]]] c"_ZTSZ28lambda_in_dependent_functionIiEvvEUlvE_\00",
-// CHECK: @[[LAMBDA_IN_DEP_X:[^\w]+]] = private unnamed_addr constant [[DEP_LAMBDA_SIZE:\[[0-9]+ x i8\]]] c"_ZTSZ28lambda_in_dependent_functionIZZ4mainENKUlvE10000_clEvEUlvE_EvvEUlvE_\00",
+// CHECK: @[[LAMBDA_IN_DEP_X:[^\w]+]] = private unnamed_addr constant [[DEP_LAMBDA_SIZE:\[[0-9]+ x i8\]]] c"_ZTSZ28lambda_in_dependent_functionIZZ4mainENKUlvE10001_clEvEUlvE_EvvEUlvE_\00",
 // CHECK: @[[LAMBDA_NO_DEP:[^\w]+]] = private unnamed_addr constant [[NO_DEP_LAMBDA_SIZE:\[[0-9]+ x i8\]]] c"_ZTSZ13lambda_no_depIidEvT_T0_EUlidE_\00",
-// CHECK: @[[LAMBDA_TWO_DEP:[^\w]+]] = private unnamed_addr constant [[DEP_LAMBDA1_SIZE:\[[0-9]+ x i8\]]] c"_ZTSZ14lambda_two_depIZZ4mainENKUlvE10000_clEvEUliE_ZZ4mainENKS0_clEvEUldE_EvvEUlvE_\00",
-// CHECK: @[[LAMBDA_TWO_DEP2:[^\w]+]] = private unnamed_addr constant [[DEP_LAMBDA2_SIZE:\[[0-9]+ x i8\]]] c"_ZTSZ14lambda_two_depIZZ4mainENKUlvE10000_clEvEUldE_ZZ4mainENKS0_clEvEUliE_EvvEUlvE_\00",
-
-// CHECK: call spir_func void @_Z18kernel_single_taskIZ4mainE7kernel2PFPKcvEEvT0_(i8* ()* @_Z4funcI4DerpEDTu20__unique_stable_nameXsrT_3strEEEv)
-// CHECK: call spir_func void @_Z18kernel_single_taskIZ4mainE7kernel3Z4mainEUlPZ4mainEUlvE0_E_EvT0_
-// CHECK: call spir_func void @puts(i8* getelementptr inbounds ([[LAMBDA_K3_SIZE]], [[LAMBDA_K3_SIZE]]* @[[LAMBDA_KERNEL3]]
-// CHECK: call spir_func void @puts(i8* getelementptr inbounds ([[INT1_SIZE]], [[INT1_SIZE]]* @[[INT1]]
-// CHECK: call spir_func void @puts(i8* getelementptr inbounds ([[STRING_SIZE]], [[STRING_SIZE]]* @[[STRING]]
-
-// CHECK: define internal spir_func void @_Z18kernel_single_taskIZ4mainE6kernelZ4mainEUlvE_EvT0_
-// CHECK: define internal spir_func void @_Z18kernel_single_taskIZ4mainE7kernel2PFPKcvEEvT0_
-// CHECK: declare spir_func i8* @_Z4funcI4DerpEDTu20__unique_stable_nameXsrT_3strEEEv
-// CHECK: define internal spir_func void @_Z18kernel_single_taskIZ4mainE7kernel3Z4mainEUlPZ4mainEUlvE0_E_EvT0_
+// CHECK: @[[LAMBDA_TWO_DEP:[^\w]+]] = private unnamed_addr constant [[DEP_LAMBDA1_SIZE:\[[0-9]+ x i8\]]] c"_ZTSZ14lambda_two_depIZZ4mainENKUlvE10001_clEvEUliE_ZZ4mainENKS0_clEvEUldE_EvvEUlvE_\00",
+// CHECK: @[[LAMBDA_TWO_DEP2:[^\w]+]] = private unnamed_addr constant [[DEP_LAMBDA2_SIZE:\[[0-9]+ x i8\]]] c"_ZTSZ14lambda_two_depIZZ4mainENKUlvE10001_clEvEUldE_ZZ4mainENKS0_clEvEUliE_EvvEUlvE_\00",
 
 extern "C" void puts(const char *) {}
 
@@ -54,9 +43,9 @@ void lambda_no_dep(Tw a, Tz b) {
   puts(__builtin_unique_stable_name(p));
 }
 
-#define DEF_IN_MACRO()                           \
-  auto MACRO_X = []() {};                        \
-  auto MACRO_Y = []() {};                        \
+#define DEF_IN_MACRO()                         \
+  auto MACRO_X = []() {};                      \
+  auto MACRO_Y = []() {};                      \
   puts(__builtin_unique_stable_name(MACRO_X)); \
   puts(__builtin_unique_stable_name(MACRO_Y));
 
@@ -77,6 +66,35 @@ template <typename KernelName, typename KernelType>
 }
 
 int main() {
+  kernel_single_task<class kernel2>(func<Derp>);
+  // CHECK: call spir_func void @_Z18kernel_single_taskIZ4mainE7kernel2PFPKcvEEvT0_(i8* ()* @_Z4funcI4DerpEDTu20__unique_stable_nameXsrT_3strEEEv)
+
+  auto l1 = []() { return 1; };
+  auto l2 = [](decltype(l1) *l = nullptr) { return 2; };
+  kernel_single_task<class kernel3>(l2);
+  puts(__builtin_unique_stable_name(l2));
+  // CHECK: call spir_func void @_Z18kernel_single_taskIZ4mainE7kernel3Z4mainEUlPZ4mainEUlvE_E_EvT0_
+  // CHECK: call spir_func void @puts(i8* getelementptr inbounds ([[LAMBDA_K3_SIZE]], [[LAMBDA_K3_SIZE]]* @[[LAMBDA_KERNEL3]]
+
+  constexpr const char str[] = "lalala";
+  static_assert(__builtin_strcmp(__builtin_unique_stable_name(str), "_ZTSA7_Kc\00") == 0, "unexpected mangling");
+
+  int i = 0;
+  puts(__builtin_unique_stable_name(i++));
+  // CHECK: store i32 0, i32* %i
+  // CHECK: call spir_func void @puts(i8* getelementptr inbounds ([[INT1_SIZE]], [[INT1_SIZE]]* @[[INT1]]
+
+  // FIXME: Ensure that j is incremented because VLAs are terrible
+  int j = 55;
+  puts(__builtin_unique_stable_name(int[++j]));
+  // CHECK: store i32 55, i32* %j
+  // CHECK: call spir_func void @puts(i8* getelementptr inbounds ([[STRING_SIZE]], [[STRING_SIZE]]* @[[STRING]]
+
+  // CHECK: define internal spir_func void @_Z18kernel_single_taskIZ4mainE7kernel2PFPKcvEEvT0_
+  // CHECK: declare spir_func i8* @_Z4funcI4DerpEDTu20__unique_stable_nameXsrT_3strEEEv
+  // CHECK: define internal spir_func void @_Z18kernel_single_taskIZ4mainE7kernel3Z4mainEUlPZ4mainEUlvE_E_EvT0_
+  // CHECK: define internal spir_func void @_Z18kernel_single_taskIZ4mainE6kernelZ4mainEUlvE0_EvT0_
+
   kernel_single_task<class kernel>(
       []() {
         puts(__builtin_unique_stable_name(int));
@@ -100,13 +118,13 @@ int main() {
         // CHECK: call spir_func void @_Z14template_paramIiEvv
 
         template_param<decltype(x)>();
-        // CHECK: call spir_func void @_Z14template_paramIZZ4mainENKUlvE_clEvEUlvE_Evv
+        // CHECK: call spir_func void @_Z14template_paramIZZ4mainENKUlvE0_clEvEUlvE_Evv
 
         lambda_in_dependent_function<int>();
         // CHECK: call spir_func void @_Z28lambda_in_dependent_functionIiEvv
 
         lambda_in_dependent_function<decltype(x)>();
-        // CHECK: call spir_func void @_Z28lambda_in_dependent_functionIZZ4mainENKUlvE_clEvEUlvE_Evv
+        // CHECK: call spir_func void @_Z28lambda_in_dependent_functionIZZ4mainENKUlvE0_clEvEUlvE_Evv
 
         lambda_no_dep<int, double>(3, 5.5);
         // CHECK: call spir_func void @_Z13lambda_no_depIidEvT_T0_(i32 3, double 5.500000e+00)
@@ -118,50 +136,30 @@ int main() {
         lambda_two_dep<decltype(y), decltype(z)>();
         // CHECK: store i32 5, i32* %a, align 4
         // CHECK: store double 1.070000e+01, double* %b, align 8
-        // CHECK: call spir_func void @_Z14lambda_two_depIZZ4mainENKUlvE_clEvEUliE_ZZ4mainENKS0_clEvEUldE_Evv
+        // CHECK: call spir_func void @_Z14lambda_two_depIZZ4mainENKUlvE0_clEvEUliE_ZZ4mainENKS0_clEvEUldE_Evv
 
         lambda_two_dep<decltype(z), decltype(y)>();
-        // CHECK: call spir_func void @_Z14lambda_two_depIZZ4mainENKUlvE_clEvEUldE_ZZ4mainENKS0_clEvEUliE_Evv
+        // CHECK: call spir_func void @_Z14lambda_two_depIZZ4mainENKUlvE0_clEvEUldE_ZZ4mainENKS0_clEvEUliE_Evv
       });
-
-  kernel_single_task<class kernel2>(func<Derp>);
-
-  auto l1 = []() { return 1; };
-  auto l2 = [](decltype(l1) *l = nullptr) { return 2; };
-  kernel_single_task<class kernel3>(l2);
-  puts(__builtin_unique_stable_name(l2));
-
-
-  // CHECK: define linkonce_odr spir_func void @_Z14template_paramIiEvv
-  // CHECK: call spir_func void @puts(i8* getelementptr inbounds ([[INT1_SIZE]], [[INT1_SIZE]]* @[[INT1]]
-
-  // CHECK: define internal spir_func void @_Z14template_paramIZZ4mainENKUlvE_clEvEUlvE_Evv
-  // CHECK: call spir_func void @puts(i8* getelementptr inbounds ([[LAMBDA_SIZE]], [[LAMBDA_SIZE]]* @[[LAMBDA]]
-
-  // CHECK: define linkonce_odr spir_func void @_Z28lambda_in_dependent_functionIiEvv
-  // CHECK: call spir_func void @puts(i8* getelementptr inbounds ([[DEP_INT_SIZE]], [[DEP_INT_SIZE]]* @[[LAMBDA_IN_DEP_INT]]
-
-  // CHECK: define internal spir_func void @_Z28lambda_in_dependent_functionIZZ4mainENKUlvE_clEvEUlvE_Evv
-  // CHECK: call spir_func void @puts(i8* getelementptr inbounds ([[DEP_LAMBDA_SIZE]], [[DEP_LAMBDA_SIZE]]* @[[LAMBDA_IN_DEP_X]]
-
-  // CHECK: define linkonce_odr spir_func void @_Z13lambda_no_depIidEvT_T0_(i32 %a, double %b)
-  // CHECK: call spir_func void @puts(i8* getelementptr inbounds ([[NO_DEP_LAMBDA_SIZE]], [[NO_DEP_LAMBDA_SIZE]]* @[[LAMBDA_NO_DEP]]
-
-  // CHECK: define internal spir_func void @_Z14lambda_two_depIZZ4mainENKUlvE_clEvEUliE_ZZ4mainENKS0_clEvEUldE_Evv
-  // CHECK: call spir_func void @puts(i8* getelementptr inbounds ([[DEP_LAMBDA1_SIZE]], [[DEP_LAMBDA1_SIZE]]* @[[LAMBDA_TWO_DEP]]
-
-  // CHECK: define internal spir_func void @_Z14lambda_two_depIZZ4mainENKUlvE_clEvEUldE_ZZ4mainENKS0_clEvEUliE_Evv
-  // CHECK: call spir_func void @puts(i8* getelementptr inbounds ([[DEP_LAMBDA2_SIZE]], [[DEP_LAMBDA2_SIZE]]* @[[LAMBDA_TWO_DEP2]]
-
-  constexpr const char str[] = "lalala";
-  static_assert(__builtin_strcmp(__builtin_unique_stable_name(str), "_ZTSA7_Kc\00") == 0, "unexpected mangling");
-
-  // FIXME: Warn about expression with side effects in unevaluated context
-  int i = 0;
-  puts(__builtin_unique_stable_name(i++));
-
-  // FIXME: Ensure that j is incremented because VLAs are terrible
-  int j = 55;
-  puts(__builtin_unique_stable_name(int[++j])); // No warning
-
 }
+
+// CHECK: define linkonce_odr spir_func void @_Z14template_paramIiEvv
+// CHECK: call spir_func void @puts(i8* getelementptr inbounds ([[INT1_SIZE]], [[INT1_SIZE]]* @[[INT1]]
+
+// CHECK: define internal spir_func void @_Z14template_paramIZZ4mainENKUlvE0_clEvEUlvE_Evv
+// CHECK: call spir_func void @puts(i8* getelementptr inbounds ([[LAMBDA_SIZE]], [[LAMBDA_SIZE]]* @[[LAMBDA]]
+
+// CHECK: define linkonce_odr spir_func void @_Z28lambda_in_dependent_functionIiEvv
+// CHECK: call spir_func void @puts(i8* getelementptr inbounds ([[DEP_INT_SIZE]], [[DEP_INT_SIZE]]* @[[LAMBDA_IN_DEP_INT]]
+
+// CHECK: define internal spir_func void @_Z28lambda_in_dependent_functionIZZ4mainENKUlvE0_clEvEUlvE_Evv
+// CHECK: call spir_func void @puts(i8* getelementptr inbounds ([[DEP_LAMBDA_SIZE]], [[DEP_LAMBDA_SIZE]]* @[[LAMBDA_IN_DEP_X]]
+
+// CHECK: define linkonce_odr spir_func void @_Z13lambda_no_depIidEvT_T0_(i32 %a, double %b)
+// CHECK: call spir_func void @puts(i8* getelementptr inbounds ([[NO_DEP_LAMBDA_SIZE]], [[NO_DEP_LAMBDA_SIZE]]* @[[LAMBDA_NO_DEP]]
+
+// CHECK: define internal spir_func void @_Z14lambda_two_depIZZ4mainENKUlvE0_clEvEUliE_ZZ4mainENKS0_clEvEUldE_Evv
+// CHECK: call spir_func void @puts(i8* getelementptr inbounds ([[DEP_LAMBDA1_SIZE]], [[DEP_LAMBDA1_SIZE]]* @[[LAMBDA_TWO_DEP]]
+
+// CHECK: define internal spir_func void @_Z14lambda_two_depIZZ4mainENKUlvE0_clEvEUldE_ZZ4mainENKS0_clEvEUliE_Evv
+// CHECK: call spir_func void @puts(i8* getelementptr inbounds ([[DEP_LAMBDA2_SIZE]], [[DEP_LAMBDA2_SIZE]]* @[[LAMBDA_TWO_DEP2]]

--- a/clang/test/CodeGenSYCL/unique_stable_name.cpp
+++ b/clang/test/CodeGenSYCL/unique_stable_name.cpp
@@ -1,7 +1,7 @@
 // RUN: %clang_cc1 -triple spir64-unknown-unknown-sycldevice -fsycl-is-device -disable-llvm-passes -emit-llvm %s -o - | FileCheck %s
 // CHECK: @[[LAMBDA_KERNEL3:[^\w]+]] = private unnamed_addr constant [[LAMBDA_K3_SIZE:\[[0-9]+ x i8\]]] c"_ZTSZ4mainEUlPZ4mainEUlvE10002_E10001_\00"
 // CHECK: @[[INT1:[^\w]+]] = private unnamed_addr constant [[INT1_SIZE:\[[0-9]+ x i8\]]] c"_ZTSi\00"
-// CHECK: @[[VLA_TEST_STRING:[^\w]+]] = private unnamed_addr constant [[STRING_SIZE:\[[0-9]+ x i8\]]] c"_ZTSAppL_ZZ4mainE1jE_i\00",
+// CHECK: @[[STRING:[^\w]+]] = private unnamed_addr constant [[STRING_SIZE:\[[0-9]+ x i8\]]] c"_ZTSAppL_ZZ4mainE1jE_i\00",
 // CHECK: @[[INT:[^\w]+]] = private unnamed_addr constant [[INT_SIZE:\[[0-9]+ x i8\]]] c"_ZTSi\00"
 // CHECK: @[[LAMBDA_X:[^\w]+]] = private unnamed_addr constant [[LAMBDA_X_SIZE:\[[0-9]+ x i8\]]] c"_ZTSZZ4mainENKUlvE10000_clEvEUlvE_\00"
 // CHECK: @[[LAMBDA_Y:[^\w]+]] = private unnamed_addr constant [[LAMBDA_Y_SIZE:\[[0-9]+ x i8\]]] c"_ZTSZZ4mainENKUlvE10000_clEvEUlvE_\00"
@@ -11,51 +11,54 @@
 // CHECK: @usn_str.9 = private unnamed_addr constant [36 x i8] c"_ZTSZZ4mainENKUlvE10000_clEvEUlvE3_\00", align 1
 // CHECK: @[[MACRO_MACRO_X:[^\w]+]] = private unnamed_addr constant [[MACRO_MACRO_SIZE:\[[0-9]+ x i8\]]] c"_ZTSZZ4mainENKUlvE10000_clEvEUlvE4_\00"
 // CHECK: @[[MACRO_MACRO_Y:[^\w]+]] = private unnamed_addr constant [[MACRO_MACRO_SIZE]] c"_ZTSZZ4mainENKUlvE10000_clEvEUlvE5_\00"
-// @usn_str.12 = private unnamed_addr constant [6 x i8] c"_ZTSi\00", align 1
 // CHECK: @[[LAMBDA:[^\w]+]] = private unnamed_addr constant [[LAMBDA_SIZE:\[[0-9]+ x i8\]]] c"_ZTSZZ4mainENKUlvE10000_clEvEUlvE_\00"
-// @usn_str.13 = private unnamed_addr constant [35 x i8] c"_ZTSZZ4mainENKUlvE10000_clEvEUlvE_\00"
 // CHECK: @[[LAMBDA_IN_DEP_INT:[^\w]+]] = private unnamed_addr constant [[DEP_INT_SIZE:\[[0-9]+ x i8\]]] c"_ZTSZ28lambda_in_dependent_functionIiEvvEUlvE_\00",
 // CHECK: @[[LAMBDA_IN_DEP_X:[^\w]+]] = private unnamed_addr constant [[DEP_LAMBDA_SIZE:\[[0-9]+ x i8\]]] c"_ZTSZ28lambda_in_dependent_functionIZZ4mainENKUlvE10000_clEvEUlvE_EvvEUlvE_\00",
 // CHECK: @[[LAMBDA_NO_DEP:[^\w]+]] = private unnamed_addr constant [[NO_DEP_LAMBDA_SIZE:\[[0-9]+ x i8\]]] c"_ZTSZ13lambda_no_depIidEvT_T0_EUlidE_\00",
 // CHECK: @[[LAMBDA_TWO_DEP:[^\w]+]] = private unnamed_addr constant [[DEP_LAMBDA1_SIZE:\[[0-9]+ x i8\]]] c"_ZTSZ14lambda_two_depIZZ4mainENKUlvE10000_clEvEUliE_ZZ4mainENKS0_clEvEUldE_EvvEUlvE_\00",
 // CHECK: @[[LAMBDA_TWO_DEP2:[^\w]+]] = private unnamed_addr constant [[DEP_LAMBDA2_SIZE:\[[0-9]+ x i8\]]] c"_ZTSZ14lambda_two_depIZZ4mainENKUlvE10000_clEvEUldE_ZZ4mainENKS0_clEvEUliE_EvvEUlvE_\00",
-//
+
 // CHECK: call spir_func void @_Z18kernel_single_taskIZ4mainE7kernel2PFPKcvEEvT0_(i8* ()* @_Z4funcI4DerpEDTu20__unique_stable_nameXsrT_3strEEEv)
 // CHECK: call spir_func void @_Z18kernel_single_taskIZ4mainE7kernel3Z4mainEUlPZ4mainEUlvE0_E_EvT0_
-//
-extern "C" void printf(const char *) {}
+// CHECK: call spir_func void @puts(i8* getelementptr inbounds ([[LAMBDA_K3_SIZE]], [[LAMBDA_K3_SIZE]]* @[[LAMBDA_KERNEL3]]
+// CHECK: call spir_func void @puts(i8* getelementptr inbounds ([[INT1_SIZE]], [[INT1_SIZE]]* @[[INT1]]
+// CHECK: call spir_func void @puts(i8* getelementptr inbounds ([[STRING_SIZE]], [[STRING_SIZE]]* @[[STRING]]
+
+// CHECK: define internal spir_func void @_Z18kernel_single_taskIZ4mainE6kernelZ4mainEUlvE_EvT0_
+// CHECK: define internal spir_func void @_Z18kernel_single_taskIZ4mainE7kernel2PFPKcvEEvT0_
+// CHECK: declare spir_func i8* @_Z4funcI4DerpEDTu20__unique_stable_nameXsrT_3strEEEv
+// CHECK: define internal spir_func void @_Z18kernel_single_taskIZ4mainE7kernel3Z4mainEUlPZ4mainEUlvE0_E_EvT0_
+
+extern "C" void puts(const char *) {}
 
 template <typename T>
 void template_param() {
-  printf(__builtin_unique_stable_name(T));
+  puts(__builtin_unique_stable_name(T));
 }
-
-template <typename T>
-T getT() { return T{}; }
 
 template <typename T>
 void lambda_in_dependent_function() {
   auto y = [] {};
-  printf(__builtin_unique_stable_name(y));
+  puts(__builtin_unique_stable_name(y));
 }
 
 template <typename Tw, typename Tz>
 void lambda_two_dep() {
   auto z = [] {};
-  printf(__builtin_unique_stable_name(z));
+  puts(__builtin_unique_stable_name(z));
 }
 
 template <typename Tw, typename Tz>
 void lambda_no_dep(Tw a, Tz b) {
   auto p = [](Tw a, Tz b) { return ((Tz)a + b); };
-  printf(__builtin_unique_stable_name(p));
+  puts(__builtin_unique_stable_name(p));
 }
 
 #define DEF_IN_MACRO()                           \
   auto MACRO_X = []() {};                        \
   auto MACRO_Y = []() {};                        \
-  printf(__builtin_unique_stable_name(MACRO_X)); \
-  printf(__builtin_unique_stable_name(MACRO_Y));
+  puts(__builtin_unique_stable_name(MACRO_X)); \
+  puts(__builtin_unique_stable_name(MACRO_Y));
 
 #define MACRO_CALLS_MACRO() \
   { DEF_IN_MACRO(); }       \
@@ -63,15 +66,10 @@ void lambda_no_dep(Tw a, Tz b) {
 
 template <typename Ty>
 auto func() -> decltype(__builtin_unique_stable_name(Ty::str));
-// CHECK: declare spir_func i8* @_Z4funcI4DerpEDTu20__unique_stable_nameXsrT_3strEEEv()
 
 struct Derp {
   static constexpr const char str[] = "derp derp derp";
 };
-
-#define IF_MACRO()              \
-  auto l1 = []() { return 1; }; \
-  constexpr const char *l1_output = __builtin_unique_stable_name(l1);
 
 template <typename KernelName, typename KernelType>
 [[clang::sycl_kernel]] void kernel_single_task(KernelType kernelFunc) {
@@ -81,42 +79,51 @@ template <typename KernelName, typename KernelType>
 int main() {
   kernel_single_task<class kernel>(
       []() {
-        printf(__builtin_unique_stable_name(int));
-        // CHECK: call spir_func void @printf(i8* getelementptr inbounds ([[INT_SIZE]], [[INT_SIZE]]* @[[INT]]
+        puts(__builtin_unique_stable_name(int));
+        // CHECK: call spir_func void @puts(i8* getelementptr inbounds ([[INT_SIZE]], [[INT_SIZE]]* @[[INT]]
 
         auto x = []() {};
-        printf(__builtin_unique_stable_name(x));
-        printf(__builtin_unique_stable_name(decltype(x)));
-        // CHECK: call spir_func void @printf(i8* getelementptr inbounds ([[LAMBDA_X_SIZE]], [[LAMBDA_X_SIZE]]* @[[LAMBDA_X]]
-        // CHECK: call spir_func void @printf(i8* getelementptr inbounds ([[LAMBDA_Y_SIZE]], [[LAMBDA_Y_SIZE]]* @[[LAMBDA_Y]]
+        puts(__builtin_unique_stable_name(x));
+        puts(__builtin_unique_stable_name(decltype(x)));
+        // CHECK: call spir_func void @puts(i8* getelementptr inbounds ([[LAMBDA_X_SIZE]], [[LAMBDA_X_SIZE]]* @[[LAMBDA_X]]
+        // CHECK: call spir_func void @puts(i8* getelementptr inbounds ([[LAMBDA_Y_SIZE]], [[LAMBDA_Y_SIZE]]* @[[LAMBDA_Y]]
 
         DEF_IN_MACRO();
-        // CHECK: call spir_func void @printf(i8* getelementptr inbounds ([[MACRO_SIZE]], [[MACRO_SIZE]]* @[[MACRO_X]]
-        // CHECK: call spir_func void @printf(i8* getelementptr inbounds ([[MACRO_SIZE]], [[MACRO_SIZE]]* @[[MACRO_Y]]
+        // CHECK: call spir_func void @puts(i8* getelementptr inbounds ([[MACRO_SIZE]], [[MACRO_SIZE]]* @[[MACRO_X]]
+        // CHECK: call spir_func void @puts(i8* getelementptr inbounds ([[MACRO_SIZE]], [[MACRO_SIZE]]* @[[MACRO_Y]]
 
         MACRO_CALLS_MACRO();
-        // CHECK: call spir_func void @printf(i8* getelementptr inbounds ([[MACRO_MACRO_SIZE]], [[MACRO_MACRO_SIZE]]* @[[MACRO_MACRO_X]]
-        // CHECK: call spir_func void @printf(i8* getelementptr inbounds ([[MACRO_MACRO_SIZE]], [[MACRO_MACRO_SIZE]]* @[[MACRO_MACRO_Y]]
+        // CHECK: call spir_func void @puts(i8* getelementptr inbounds ([[MACRO_MACRO_SIZE]], [[MACRO_MACRO_SIZE]]* @[[MACRO_MACRO_X]]
+        // CHECK: call spir_func void @puts(i8* getelementptr inbounds ([[MACRO_MACRO_SIZE]], [[MACRO_MACRO_SIZE]]* @[[MACRO_MACRO_Y]]
 
+        // CHECK: call spir_func void @_Z14template_paramIiEvv
+        // CHECK: call spir_func void @_Z14template_paramIZZ4mainENKUlvE_clEvEUlvE_Evv
+        // CHECK: call spir_func void @_Z28lambda_in_dependent_functionIiEvv
+        // CHECK: call spir_func void @_Z28lambda_in_dependent_functionIZZ4mainENKUlvE_clEvEUlvE_Evv
+        // CHECK: call spir_func void @_Z13lambda_no_depIidEvT_T0_(i32 3, double 5.500000e+00)
+        // CHECK: store i32 5, i32* %a, align 4
+        // CHECK: store double 1.070000e+01, double* %b, align 8
+        // CHECK: call spir_func void @_Z14lambda_two_depIZZ4mainENKUlvE_clEvEUliE_ZZ4mainENKS0_clEvEUldE_Evv
+        // CHECK: call spir_func void @_Z14lambda_two_depIZZ4mainENKUlvE_clEvEUldE_ZZ4mainENKS0_clEvEUliE_Evv
         template_param<int>();
         // CHECK: define linkonce_odr spir_func void @_Z14template_paramIiEvv
-        // CHECK: call spir_func void @printf(i8* getelementptr inbounds ([[INT1_SIZE]], [[INT1_SIZE]]* @[[INT1]]
+        // CHECK: call spir_func void @puts(i8* getelementptr inbounds ([[INT1_SIZE]], [[INT1_SIZE]]* @[[INT1]]
 
         template_param<decltype(x)>();
         // CHECK: define internal spir_func void @_Z14template_paramIZZ4mainENKUlvE_clEvEUlvE_Evv
-        // CHECK: call spir_func void @printf(i8* getelementptr inbounds ([[LAMBDA_SIZE]], [[LAMBDA_SIZE]]* @[[LAMBDA]]
+        // CHECK: call spir_func void @puts(i8* getelementptr inbounds ([[LAMBDA_SIZE]], [[LAMBDA_SIZE]]* @[[LAMBDA]]
 
         lambda_in_dependent_function<int>();
         // CHECK: define linkonce_odr spir_func void @_Z28lambda_in_dependent_functionIiEvv
-        // CHECK: call spir_func void @printf(i8* getelementptr inbounds ([[DEP_INT_SIZE]], [[DEP_INT_SIZE]]* @[[LAMBDA_IN_DEP_INT]]
+        // CHECK: call spir_func void @puts(i8* getelementptr inbounds ([[DEP_INT_SIZE]], [[DEP_INT_SIZE]]* @[[LAMBDA_IN_DEP_INT]]
 
         lambda_in_dependent_function<decltype(x)>();
         // CHECK: define internal spir_func void @_Z28lambda_in_dependent_functionIZZ4mainENKUlvE_clEvEUlvE_Evv
-        // CHECK: call spir_func void @printf(i8* getelementptr inbounds ([[DEP_LAMBDA_SIZE]], [[DEP_LAMBDA_SIZE]]* @[[LAMBDA_IN_DEP_X]]
+        // CHECK: call spir_func void @puts(i8* getelementptr inbounds ([[DEP_LAMBDA_SIZE]], [[DEP_LAMBDA_SIZE]]* @[[LAMBDA_IN_DEP_X]]
 
         lambda_no_dep<int, double>(3, 5.5);
         // CHECK: define linkonce_odr spir_func void @_Z13lambda_no_depIidEvT_T0_(i32 %a, double %b)
-        // CHECK: call spir_func void @printf(i8* getelementptr inbounds ([[NO_DEP_LAMBDA_SIZE]], [[NO_DEP_LAMBDA_SIZE]]* @[[LAMBDA_NO_DEP]]
+        // CHECK: call spir_func void @puts(i8* getelementptr inbounds ([[NO_DEP_LAMBDA_SIZE]], [[NO_DEP_LAMBDA_SIZE]]* @[[LAMBDA_NO_DEP]]
 
         int a = 5;
         double b = 10.7;
@@ -124,40 +131,32 @@ int main() {
         auto z = [](double b) { return b; };
         lambda_two_dep<decltype(y), decltype(z)>();
         // CHECK: define internal spir_func void @_Z14lambda_two_depIZZ4mainENKUlvE_clEvEUliE_ZZ4mainENKS0_clEvEUldE_Evv
-        // CHECK: call spir_func void @printf(i8* getelementptr inbounds ([[DEP_LAMBDA1_SIZE]], [[DEP_LAMBDA1_SIZE]]* @[[LAMBDA_TWO_DEP]]
+        // CHECK: call spir_func void @puts(i8* getelementptr inbounds ([[DEP_LAMBDA1_SIZE]], [[DEP_LAMBDA1_SIZE]]* @[[LAMBDA_TWO_DEP]]
 
         lambda_two_dep<decltype(z), decltype(y)>();
         // CHECK: define internal spir_func void @_Z14lambda_two_depIZZ4mainENKUlvE_clEvEUldE_ZZ4mainENKS0_clEvEUliE_Evv
-        // CHECK: call spir_func void @printf(i8* getelementptr inbounds ([[DEP_LAMBDA2_SIZE]], [[DEP_LAMBDA2_SIZE]]* @[[LAMBDA_TWO_DEP2]]
+        // CHECK: call spir_func void @puts(i8* getelementptr inbounds ([[DEP_LAMBDA2_SIZE]], [[DEP_LAMBDA2_SIZE]]* @[[LAMBDA_TWO_DEP2]]
       });
 
   kernel_single_task<class kernel2>(func<Derp>);
-  // moved check to the beginning of the file because Filecheck has trouble matching these here
-  // call spir_func void @_Z18kernel_single_taskIZ4mainE7kernel2PFPKcvEEvT0_(i8* ()* @_Z4funcI4DerpEDTu20__unique_stable_nameXsrT_3strEEEv)
 
   auto l1 = []() { return 1; };
   auto l2 = [](decltype(l1) *l = nullptr) { return 2; };
   kernel_single_task<class kernel3>(l2);
-  printf(__builtin_unique_stable_name(l2));
-  // moved the check to the beginning of the file because of trouble matching them here
-  // call spir_func void @_Z18kernel_single_taskIZ4mainE7kernel3Z4mainEUlPZ4mainEUlvE0_E_EvT0_
+  puts(__builtin_unique_stable_name(l2));
 
   // TO-DO
-  //__builtin_strcmp doesn't seem to like __builtin_unique_stable_name(str)
-  constexpr const char *mangled_str = "_ZTSA7_Kc"; //=__builtin_unique_stable_name(str)
-  static_assert(__builtin_strcmp(mangled_str, "_ZTSA7_Kc\00") == 0, "unexpected mangling");
+  constexpr const char str[] = "lalala";
+  static_assert(__builtin_strcmp(__builtin_unique_stable_name(str), "_ZTSA7_Kc\00") == 0, "unexpected mangling");
 
   // FIXME: Warn about expression with side effects in unevaluated context
   int i = 0;
-  printf(__builtin_unique_stable_name(i++));
-  //@usn_str.1 = private unnamed_addr constant [6 x i8] c"_ZTSi\00", align 1
-  // store i32 0, i32* %i, align 4
-  // call spir_func void @printf(i8* getelementptr inbounds ([6 x i8], [6 x i8]* @usn_str.1, i32 0, i32 0))
+  puts(__builtin_unique_stable_name(i++));
 
   // FIXME: Ensure that j is incremented because VLAs are terrible
   int j = 55;
-  printf(__builtin_unique_stable_name(int[++j])); // No warning
-  //@usn_str.2 = private unnamed_addr constant [23 x i8] c"_ZTSAppL_ZZ4mainE1jE_i\00"
-  // store i32 55, i32* %j, align 4
-  // call spir_func void @printf(i8* getelementptr inbounds ([23 x i8], [23 x i8]* @usn_str.2, i32 0, i32 0))
+  puts(__builtin_unique_stable_name(int[++j])); // No warning
+
+
+
 }

--- a/clang/test/CodeGenSYCL/unique_stable_name.cpp
+++ b/clang/test/CodeGenSYCL/unique_stable_name.cpp
@@ -96,46 +96,32 @@ int main() {
         // CHECK: call spir_func void @puts(i8* getelementptr inbounds ([[MACRO_MACRO_SIZE]], [[MACRO_MACRO_SIZE]]* @[[MACRO_MACRO_X]]
         // CHECK: call spir_func void @puts(i8* getelementptr inbounds ([[MACRO_MACRO_SIZE]], [[MACRO_MACRO_SIZE]]* @[[MACRO_MACRO_Y]]
 
-        // CHECK: call spir_func void @_Z14template_paramIiEvv
-        // CHECK: call spir_func void @_Z14template_paramIZZ4mainENKUlvE_clEvEUlvE_Evv
-        // CHECK: call spir_func void @_Z28lambda_in_dependent_functionIiEvv
-        // CHECK: call spir_func void @_Z28lambda_in_dependent_functionIZZ4mainENKUlvE_clEvEUlvE_Evv
-        // CHECK: call spir_func void @_Z13lambda_no_depIidEvT_T0_(i32 3, double 5.500000e+00)
-        // CHECK: store i32 5, i32* %a, align 4
-        // CHECK: store double 1.070000e+01, double* %b, align 8
-        // CHECK: call spir_func void @_Z14lambda_two_depIZZ4mainENKUlvE_clEvEUliE_ZZ4mainENKS0_clEvEUldE_Evv
-        // CHECK: call spir_func void @_Z14lambda_two_depIZZ4mainENKUlvE_clEvEUldE_ZZ4mainENKS0_clEvEUliE_Evv
         template_param<int>();
-        // CHECK: define linkonce_odr spir_func void @_Z14template_paramIiEvv
-        // CHECK: call spir_func void @puts(i8* getelementptr inbounds ([[INT1_SIZE]], [[INT1_SIZE]]* @[[INT1]]
+        // CHECK: call spir_func void @_Z14template_paramIiEvv
 
         template_param<decltype(x)>();
-        // CHECK: define internal spir_func void @_Z14template_paramIZZ4mainENKUlvE_clEvEUlvE_Evv
-        // CHECK: call spir_func void @puts(i8* getelementptr inbounds ([[LAMBDA_SIZE]], [[LAMBDA_SIZE]]* @[[LAMBDA]]
+        // CHECK: call spir_func void @_Z14template_paramIZZ4mainENKUlvE_clEvEUlvE_Evv
 
         lambda_in_dependent_function<int>();
-        // CHECK: define linkonce_odr spir_func void @_Z28lambda_in_dependent_functionIiEvv
-        // CHECK: call spir_func void @puts(i8* getelementptr inbounds ([[DEP_INT_SIZE]], [[DEP_INT_SIZE]]* @[[LAMBDA_IN_DEP_INT]]
+        // CHECK: call spir_func void @_Z28lambda_in_dependent_functionIiEvv
 
         lambda_in_dependent_function<decltype(x)>();
-        // CHECK: define internal spir_func void @_Z28lambda_in_dependent_functionIZZ4mainENKUlvE_clEvEUlvE_Evv
-        // CHECK: call spir_func void @puts(i8* getelementptr inbounds ([[DEP_LAMBDA_SIZE]], [[DEP_LAMBDA_SIZE]]* @[[LAMBDA_IN_DEP_X]]
+        // CHECK: call spir_func void @_Z28lambda_in_dependent_functionIZZ4mainENKUlvE_clEvEUlvE_Evv
 
         lambda_no_dep<int, double>(3, 5.5);
-        // CHECK: define linkonce_odr spir_func void @_Z13lambda_no_depIidEvT_T0_(i32 %a, double %b)
-        // CHECK: call spir_func void @puts(i8* getelementptr inbounds ([[NO_DEP_LAMBDA_SIZE]], [[NO_DEP_LAMBDA_SIZE]]* @[[LAMBDA_NO_DEP]]
+        // CHECK: call spir_func void @_Z13lambda_no_depIidEvT_T0_(i32 3, double 5.500000e+00)
 
         int a = 5;
         double b = 10.7;
         auto y = [](int a) { return a; };
         auto z = [](double b) { return b; };
         lambda_two_dep<decltype(y), decltype(z)>();
-        // CHECK: define internal spir_func void @_Z14lambda_two_depIZZ4mainENKUlvE_clEvEUliE_ZZ4mainENKS0_clEvEUldE_Evv
-        // CHECK: call spir_func void @puts(i8* getelementptr inbounds ([[DEP_LAMBDA1_SIZE]], [[DEP_LAMBDA1_SIZE]]* @[[LAMBDA_TWO_DEP]]
+        // CHECK: store i32 5, i32* %a, align 4
+        // CHECK: store double 1.070000e+01, double* %b, align 8
+        // CHECK: call spir_func void @_Z14lambda_two_depIZZ4mainENKUlvE_clEvEUliE_ZZ4mainENKS0_clEvEUldE_Evv
 
         lambda_two_dep<decltype(z), decltype(y)>();
-        // CHECK: define internal spir_func void @_Z14lambda_two_depIZZ4mainENKUlvE_clEvEUldE_ZZ4mainENKS0_clEvEUliE_Evv
-        // CHECK: call spir_func void @puts(i8* getelementptr inbounds ([[DEP_LAMBDA2_SIZE]], [[DEP_LAMBDA2_SIZE]]* @[[LAMBDA_TWO_DEP2]]
+        // CHECK: call spir_func void @_Z14lambda_two_depIZZ4mainENKUlvE_clEvEUldE_ZZ4mainENKS0_clEvEUliE_Evv
       });
 
   kernel_single_task<class kernel2>(func<Derp>);
@@ -145,7 +131,28 @@ int main() {
   kernel_single_task<class kernel3>(l2);
   puts(__builtin_unique_stable_name(l2));
 
-  // TO-DO
+
+  // CHECK: define linkonce_odr spir_func void @_Z14template_paramIiEvv
+  // CHECK: call spir_func void @puts(i8* getelementptr inbounds ([[INT1_SIZE]], [[INT1_SIZE]]* @[[INT1]]
+
+  // CHECK: define internal spir_func void @_Z14template_paramIZZ4mainENKUlvE_clEvEUlvE_Evv
+  // CHECK: call spir_func void @puts(i8* getelementptr inbounds ([[LAMBDA_SIZE]], [[LAMBDA_SIZE]]* @[[LAMBDA]]
+
+  // CHECK: define linkonce_odr spir_func void @_Z28lambda_in_dependent_functionIiEvv
+  // CHECK: call spir_func void @puts(i8* getelementptr inbounds ([[DEP_INT_SIZE]], [[DEP_INT_SIZE]]* @[[LAMBDA_IN_DEP_INT]]
+
+  // CHECK: define internal spir_func void @_Z28lambda_in_dependent_functionIZZ4mainENKUlvE_clEvEUlvE_Evv
+  // CHECK: call spir_func void @puts(i8* getelementptr inbounds ([[DEP_LAMBDA_SIZE]], [[DEP_LAMBDA_SIZE]]* @[[LAMBDA_IN_DEP_X]]
+
+  // CHECK: define linkonce_odr spir_func void @_Z13lambda_no_depIidEvT_T0_(i32 %a, double %b)
+  // CHECK: call spir_func void @puts(i8* getelementptr inbounds ([[NO_DEP_LAMBDA_SIZE]], [[NO_DEP_LAMBDA_SIZE]]* @[[LAMBDA_NO_DEP]]
+
+  // CHECK: define internal spir_func void @_Z14lambda_two_depIZZ4mainENKUlvE_clEvEUliE_ZZ4mainENKS0_clEvEUldE_Evv
+  // CHECK: call spir_func void @puts(i8* getelementptr inbounds ([[DEP_LAMBDA1_SIZE]], [[DEP_LAMBDA1_SIZE]]* @[[LAMBDA_TWO_DEP]]
+
+  // CHECK: define internal spir_func void @_Z14lambda_two_depIZZ4mainENKUlvE_clEvEUldE_ZZ4mainENKS0_clEvEUliE_Evv
+  // CHECK: call spir_func void @puts(i8* getelementptr inbounds ([[DEP_LAMBDA2_SIZE]], [[DEP_LAMBDA2_SIZE]]* @[[LAMBDA_TWO_DEP2]]
+
   constexpr const char str[] = "lalala";
   static_assert(__builtin_strcmp(__builtin_unique_stable_name(str), "_ZTSA7_Kc\00") == 0, "unexpected mangling");
 
@@ -156,7 +163,5 @@ int main() {
   // FIXME: Ensure that j is incremented because VLAs are terrible
   int j = 55;
   puts(__builtin_unique_stable_name(int[++j])); // No warning
-
-
 
 }

--- a/clang/test/CodeGenSYCL/unique_stable_name.cpp
+++ b/clang/test/CodeGenSYCL/unique_stable_name.cpp
@@ -1,5 +1,5 @@
 // RUN: %clang_cc1 -triple spir64-unknown-unknown-sycldevice -fsycl-is-device -disable-llvm-passes -emit-llvm %s -o - | FileCheck %s
-// CHECK: @[[LAMBDA_KERNEL3]] = private unnamed_addr constant [[LAMBDA_K3_SIZE:\[[0-9]+ x i8\]]] c"_ZTSZ4mainEUlPZ4mainEUlvE10001_E10002_\00"
+// CHECK: @[[LAMBDA_KERNEL3:[^\w]+]] = private unnamed_addr constant [[LAMBDA_K3_SIZE:\[[0-9]+ x i8\]]] c"_ZTSZ4mainEUlPZ4mainEUlvE10001_E10002_\00"
 // CHECK: @[[INT:[^\w]+]] = private unnamed_addr constant [[INT_SIZE:\[[0-9]+ x i8\]]] c"_ZTSi\00"
 // CHECK: @[[LAMBDA_X:[^\w]+]] = private unnamed_addr constant [[LAMBDA_X_SIZE:\[[0-9]+ x i8\]]] c"_ZTSZZ4mainENKUlvE10000_clEvEUlvE_\00"
 // CHECK: @[[LAMBDA_Y:[^\w]+]] = private unnamed_addr constant [[LAMBDA_Y_SIZE:\[[0-9]+ x i8\]]] c"_ZTSZZ4mainENKUlvE10000_clEvEUlvE_\00"
@@ -7,11 +7,13 @@
 // CHECK: @[[MACRO_Y:[^\w]+]] =  private unnamed_addr constant [[MACRO_SIZE]] c"_ZTSZZ4mainENKUlvE10000_clEvEUlvE1_\00"
 // CHECK: @[[MACRO_MACRO_X:[^\w]+]] = private unnamed_addr constant [[MACRO_MACRO_SIZE:\[[0-9]+ x i8\]]] c"_ZTSZZ4mainENKUlvE10000_clEvEUlvE4_\00"
 // CHECK: @[[MACRO_MACRO_Y:[^\w]+]] = private unnamed_addr constant [[MACRO_MACRO_SIZE]] c"_ZTSZZ4mainENKUlvE10000_clEvEUlvE5_\00"
+// CHECK: @[[LAMBDA:[^\w]+]] = private unnamed_addr constant [[LAMBDA_SIZE:\[[0-9]+ x i8\]]] c"_ZTSZZ4mainENKUlvE10000_clEvEUlvE_\00"
+// @usn_str.11 = private unnamed_addr constant [35 x i8] c"_ZTSZZ4mainENKUlvE10000_clEvEUlvE_\00"
 // CHECK: @[[LAMBDA_IN_DEP_INT:[^\w]+]] = private unnamed_addr constant [[DEP_INT_SIZE:\[[0-9]+ x i8\]]] c"_ZTSZ28lambda_in_dependent_functionIiEvvEUlvE_\00",
 // CHECK: @[[LAMBDA_IN_DEP_X:[^\w]+]] = private unnamed_addr constant [[DEP_LAMBDA_SIZE:\[[0-9]+ x i8\]]] c"_ZTSZ28lambda_in_dependent_functionIZZ4mainENKUlvE10000_clEvEUlvE_EvvEUlvE_\00",
-// CHECK: @[[LAMBDA_NO_DEP:[^\w]+]] = private unnamed_addr constant [[NO_DEP_LAMBDA_SIZE:\[[0-9]+ x i8\]]] c"_ZTSZ13lambda_no_depIidEvT_T0_EUlidE_\00"
-// CHECK: @[[LAMBDA_TWO_DEP:[^\w]+]] = private unnamed_addr constant [[DEP_LAMBDA1_SIZE:\[[0-9]+ x i8\]]] c"_ZTSZ14lambda_two_depIZZ4mainENKUlvE10000_clEvEUliE_ZZ4mainENKS0_clEvEUldE_EvvEUlvE_\00"
-// CHECK: @[[LAMBDA_TWO_DEP2:[^\w]+]] = private unnamed_addr constant [[DEP_LAMBDA2_SIZE:\[0-9]+ x i8\]]] c"_ZTSZ14lambda_two_depIZZ4mainENKUlvE10000_clEvEUldE_ZZ4mainENKS0_clEvEUliE_EvvEUlvE_\00"
+// CHECK: @[[LAMBDA_NO_DEP:[^\w]+]] = private unnamed_addr constant [[NO_DEP_LAMBDA_SIZE:\[[0-9]+ x i8\]]] c"_ZTSZ13lambda_no_depIidEvT_T0_EUlidE_\00",
+// CHECK: @[[LAMBDA_TWO_DEP:[^\w]+]] = private unnamed_addr constant [[DEP_LAMBDA1_SIZE:\[[0-9]+ x i8\]]] c"_ZTSZ14lambda_two_depIZZ4mainENKUlvE10000_clEvEUliE_ZZ4mainENKS0_clEvEUldE_EvvEUlvE_\00",
+// CHECK: @[[LAMBDA_TWO_DEP2:[^\w]+]] = private unnamed_addr constant [[DEP_LAMBDA2_SIZE:\[[0-9]+ x i8\]]] c"_ZTSZ14lambda_two_depIZZ4mainENKUlvE10000_clEvEUldE_ZZ4mainENKS0_clEvEUliE_EvvEUlvE_\00",
 //
 extern "C" void printf(const char *) {}
 
@@ -95,21 +97,20 @@ int main() {
         // CHECK: call spir_func void @printf(i8* getelementptr inbounds ([[INT_SIZE]], [[INT_SIZE]]* @[[INT]]
 
         template_param<decltype(x)>();
-        // CHECK: define internal spir_func void @"_Z14template_paramIZZ4mainENK3
-        // CHECK: call spir_func void @printf(i8* getelementptr inbounds ([[LAMBDA_X_SIZE]], [[LAMBDA_X_SIZE]]* @[[LAMBDA_X]]
+        // CHECK: define internal spir_func void @"_Z14template_paramIZZ4mainENK3$_0clEvEUlvE_Evv"
+        // CHECK: call spir_func void @printf(i8* getelementptr inbounds ([[LAMBDA_SIZE]], [[LAMBDA_SIZE]]* @[[LAMBDA]]
 
         lambda_in_dependent_function<int>();
         // CHECK: define linkonce_odr spir_func void @_Z28lambda_in_dependent_functionIiEvv
         // CHECK: call spir_func void @printf(i8* getelementptr inbounds ([[DEP_INT_SIZE]], [[DEP_INT_SIZE]]* @[[LAMBDA_IN_DEP_INT]]
 
         lambda_in_dependent_function<decltype(x)>();
-        // CHECK: define internal spir_func void @_Z28lambda_in_dependent_functionIZZ4mainENK3$_0clEvEUlvE_Evv
+        // CHECK: define internal spir_func void @"_Z28lambda_in_dependent_functionIZZ4mainENK3$_0clEvEUlvE_Evv"
         // CHECK: call spir_func void @printf(i8* getelementptr inbounds ([[DEP_LAMBDA_SIZE]], [[DEP_LAMBDA_SIZE]]* @[[LAMBDA_IN_DEP_X]]
 
         lambda_no_dep<int, double>(3, 5.5);
         // CHECK: define linkonce_odr spir_func void @_Z13lambda_no_depIidEvT_T0_(i32 %a, double %b)
-        // CHECK: call spir_func void @printf(i8* getelementptr inbounds ([38 x i8], [38 x i8]* @usn_str.13, i32 0, i32 0)) #1
-        //  call spir_func void @printf(i8* getelementptr inbounds ([[NO_DEP_LAMBDA_SIZE]], [[NO_DEP_LAMBDA_SIZE]]* [[LAMBDA_NO_DEP]]
+        // CHECK: call spir_func void @printf(i8* getelementptr inbounds ([[NO_DEP_LAMBDA_SIZE]], [[NO_DEP_LAMBDA_SIZE]]* @[[LAMBDA_NO_DEP]]
 
         int a = 5;
         double b = 10.7;
@@ -117,11 +118,11 @@ int main() {
         auto z = [](double b) { return b; };
         lambda_two_dep<decltype(y), decltype(z)>();
         // CHECK: define internal spir_func void @"_Z14lambda_two_depIZZ4mainENK3$_0clEvEUliE_ZZ4mainENKS0_clEvEUldE_Evv"
-        // CHECK: call spir_func void @printf(i8* getelementptr inbounds ([[DEP_LAMBDA1_SIZE]], [[DEP_LAMBDA1_SIZE]]* [[LAMBDA_TWO_DEP]]
+        // CHECK: call spir_func void @printf(i8* getelementptr inbounds ([[DEP_LAMBDA1_SIZE]], [[DEP_LAMBDA1_SIZE]]* @[[LAMBDA_TWO_DEP]]
 
         lambda_two_dep<decltype(z), decltype(y)>();
         // CHECK: define internal spir_func void @"_Z14lambda_two_depIZZ4mainENK3$_0clEvEUldE_ZZ4mainENKS0_clEvEUliE_Evv"()
-        // CHECK: call spir_func void @printf(i8* getelementptr inbounds ([[DEP_LAMBDA2_SIZE]], [[DEP_LAMBDA2_SIZE]]* [[LAMBDA_TWO_DEP]]
+        // CHECK: call spir_func void @printf(i8* getelementptr inbounds ([[DEP_LAMBDA2_SIZE]], [[DEP_LAMBDA2_SIZE]]* @[[LAMBDA_TWO_DEP2]]
       });
 
   kernel_single_task<class kernel2>(func<Derp>);

--- a/clang/test/CodeGenSYCL/unique_stable_name.cpp
+++ b/clang/test/CodeGenSYCL/unique_stable_name.cpp
@@ -77,7 +77,7 @@ int main() {
   // CHECK: call spir_func void @puts(i8* getelementptr inbounds ([[LAMBDA_K3_SIZE]], [[LAMBDA_K3_SIZE]]* @[[LAMBDA_KERNEL3]]
 
   constexpr const char str[] = "lalala";
-  static_assert(__builtin_strcmp(__builtin_unique_stable_name(str), "_ZTSA7_Kc\00") == 0, "unexpected mangling");
+  static_assert(__builtin_strcmp(__builtin_unique_stable_name(str), "_ZTSA7_Kc\0") == 0, "unexpected mangling");
 
   int i = 0;
   puts(__builtin_unique_stable_name(i++));

--- a/clang/test/CodeGenSYCL/unique_stable_name.cpp
+++ b/clang/test/CodeGenSYCL/unique_stable_name.cpp
@@ -1,5 +1,4 @@
 // RUN: %clang_cc1 -triple spir64-unknown-unknown-sycldevice -fsycl-is-device -disable-llvm-passes -emit-llvm %s -o - | FileCheck %s
-// RUN: %clang_cc1 -triple spir64-unknown-unknown-sycldevice -DERROR -fsycl-is-device -disable-llvm-passes -emit-llvm %s -o - | FileCheck %s
 // CHECK: @[[LAMBDA_KERNEL3]] = private unnamed_addr constant [[LAMBDA_K3_SIZE:\[[0-9]+ x i8\]]] c"_ZTSZ4mainEUlPZ4mainEUlvE10001_E10002_\00"
 // CHECK: @[[INT:[^\w]+]] = private unnamed_addr constant [[INT_SIZE:\[[0-9]+ x i8\]]] c"_ZTSi\00"
 // CHECK: @[[LAMBDA_X:[^\w]+]] = private unnamed_addr constant [[LAMBDA_X_SIZE:\[[0-9]+ x i8\]]] c"_ZTSZZ4mainENKUlvE10000_clEvEUlvE_\00"
@@ -124,10 +123,10 @@ int main() {
         // CHECK: define internal spir_func void @"_Z14lambda_two_depIZZ4mainENK3$_0clEvEUldE_ZZ4mainENKS0_clEvEUliE_Evv"()
         // CHECK: call spir_func void @printf(i8* getelementptr inbounds ([[DEP_LAMBDA2_SIZE]], [[DEP_LAMBDA2_SIZE]]* [[LAMBDA_TWO_DEP]]
       });
-#ifdef DERROR
-  // CHECK: expected-error@+1{{unique-stable-name mangling not implemented yet}}
-  kernel_single_task<class kernel2>(func<Derp>());
-#endif
+
+  kernel_single_task<class kernel2>(func<Derp>);
+  // CHECK: define internal spir_func void @_Z18kernel_single_taskIZ4mainE7kernel2PFPKcvEEvT0_
+  // CHECK: call spir_func void @_Z18kernel_single_taskIZ4mainE7kernel2PFPKcvEEvT0_(i8* ()* @_Z4funcI4DerpEDTu20__unique_stable_nameXsrT_3strEEEv)
 
   auto l1 = []() { return 1; };
   auto l2 = [](decltype(l1) *l = nullptr) { return 2; };

--- a/clang/test/CodeGenSYCL/unique_stable_name.cpp
+++ b/clang/test/CodeGenSYCL/unique_stable_name.cpp
@@ -1,0 +1,96 @@
+// RUN: %clang_cc1 -triple spir64-unknown-unknown-sycldevice -fsycl-is-device -disable-llvm-passes -emit-llvm %s -o - | FileCheck %s
+// CHECK: @[[INT:[^\w]+]] = private unnamed_addr constant [[INT_SIZE:\[[0-9]+ x i8\]]] c"_ZTSi\00"
+// CHECK: @[[LAMBDA_X:[^\w]+]] = private unnamed_addr constant [[LAMBDA_X_SIZE:\[[0-9]+ x i8\]]] c"_ZTSZZ4mainENKUlvE10000_clEvEUlvE_\00"
+// CHECK: @[[LAMBDA_Y:[^\w]+]] = private unnamed_addr constant [[LAMBDA_Y_SIZE:\[[0-9]+ x i8\]]] c"_ZTSZZ4mainENKUlvE10000_clEvEUlvE_\00"
+// CHECK: @[[MACRO_X:[^\w]+]] = private unnamed_addr constant [[MACRO_SIZE:\[[0-9]+ x i8\]]] c"_ZTSZZ4mainENKUlvE10000_clEvEUlvE0_\00"
+// CHECK: @[[MACRO_Y:[^\w]+]] =  private unnamed_addr constant [[MACRO_SIZE]] c"_ZTSZZ4mainENKUlvE10000_clEvEUlvE1_\00"
+// CHECK: @[[MACRO_MACRO_X:[^\w]+]] = private unnamed_addr constant [[MACRO_MACRO_SIZE:\[[0-9]+ x i8\]]] c"_ZTSZZ4mainENKUlvE10000_clEvEUlvE4_\00"
+// CHECK: @[[MACRO_MACRO_Y:[^\w]+]] = private unnamed_addr constant [[MACRO_MACRO_SIZE]] c"_ZTSZZ4mainENKUlvE10000_clEvEUlvE5_\00"
+// CHECK: @[[LAMBDA_IN_DEP_INT:[^\w]+]] = private unnamed_addr constant [[DEP_INT_SIZE:\[[0-9]+ x i8\]]] c"_ZTSZ28lambda_in_dependent_functionIiEvvEUlvE_\00",
+// CHECK: @[[LAMBDA_IN_DEP_X:[^\w]+]] = private unnamed_addr constant [[DEP_LAMBDA_SIZE:\[[0-9]+ x i8\]]] c"_ZTSZ28lambda_in_dependent_functionIZZ4mainENKUlvE10000_clEvEUlvE_EvvEUlvE_\00",
+// CHECK: @[[LAMBDA_TWO_DEP:[^\w]+]] = private unnamed_addr constant [[DEP_LAMBDA1_SIZE:\[[0-9]+ x i8\]]] c"_ZTSZ30lambda_two_dependent_functionsIidEvT_T0_EUlidE_\00"
+extern "C" void printf(const char *) {}
+
+template <typename T>
+void template_param() {
+  printf(__builtin_unique_stable_name(T));
+}
+
+template <typename T>
+T getT() { return T{}; }
+
+template <typename T>
+void lambda_in_dependent_function() {
+  auto y = [] {};
+  printf(__builtin_unique_stable_name(y));
+}
+
+template <typename Tw, typename Tz>
+void lambda_two_dependent_functions(Tw a, Tz b) {
+  //auto w = [](Tw a) {return a};
+  //auto z = [](Tz b) {return b};
+  //auto y = [] {};
+  auto p = [](Tw a, Tz b) { return ((Tz)a+b); };
+  printf(__builtin_unique_stable_name(p));
+}
+
+#define DEF_IN_MACRO()                                  \
+  auto MACRO_X = []() {};auto MACRO_Y = []() {};        \
+  printf(__builtin_unique_stable_name(MACRO_X));        \
+  printf(__builtin_unique_stable_name(MACRO_Y));
+
+#define MACRO_CALLS_MACRO()                             \
+  {DEF_IN_MACRO();}{DEF_IN_MACRO();}
+
+template <typename KernelName, typename KernelType>
+[[clang::sycl_kernel]] void kernel_single_task(KernelType kernelFunc) {
+  kernelFunc();
+}
+
+int main() {
+  kernel_single_task<class kernel>(
+    []() {
+      printf(__builtin_unique_stable_name(int));
+      // CHECK: call spir_func void @printf(i8* getelementptr inbounds ([[INT_SIZE]], [[INT_SIZE]]* @[[INT]]
+
+      auto x = [](){};
+      printf(__builtin_unique_stable_name(x));
+      printf(__builtin_unique_stable_name(decltype(x)));
+      // CHECK: call spir_func void @printf(i8* getelementptr inbounds ([[LAMBDA_X_SIZE]], [[LAMBDA_X_SIZE]]* @[[LAMBDA_X]]
+      // CHECK: call spir_func void @printf(i8* getelementptr inbounds ([[LAMBDA_Y_SIZE]], [[LAMBDA_Y_SIZE]]* @[[LAMBDA_Y]] 
+
+      DEF_IN_MACRO();
+      // CHECK: call spir_func void @printf(i8* getelementptr inbounds ([[MACRO_SIZE]], [[MACRO_SIZE]]* @[[MACRO_X]]
+      // CHECK: call spir_func void @printf(i8* getelementptr inbounds ([[MACRO_SIZE]], [[MACRO_SIZE]]* @[[MACRO_Y]]
+
+      MACRO_CALLS_MACRO();
+      // CHECK: call spir_func void @printf(i8* getelementptr inbounds ([[MACRO_MACRO_SIZE]], [[MACRO_MACRO_SIZE]]* @[[MACRO_MACRO_X]]
+      // CHECK: call spir_func void @printf(i8* getelementptr inbounds ([[MACRO_MACRO_SIZE]], [[MACRO_MACRO_SIZE]]* @[[MACRO_MACRO_Y]]
+
+      template_param<int>();
+      // CHECK: define linkonce_odr spir_func void @_Z14template_paramIiEvv
+      // CHECK: call spir_func void @printf(i8* getelementptr inbounds ([[INT_SIZE]], [[INT_SIZE]]* @[[INT]]
+
+      template_param<decltype(x)>();
+      // CHECK: define internal spir_func void @"_Z14template_paramIZZ4mainENK3
+      // CHECK: call spir_func void @printf(i8* getelementptr inbounds ([[LAMBDA_X_SIZE]], [[LAMBDA_X_SIZE]]* @[[LAMBDA_X]]
+
+      lambda_in_dependent_function<int>();
+      // CHECK: define linkonce_odr spir_func void @_Z28lambda_in_dependent_functionIiEvv
+      // CHECK: call spir_func void @printf(i8* getelementptr inbounds ([[DEP_INT_SIZE]], [[DEP_INT_SIZE]]* @[[LAMBDA_IN_DEP_INT]]
+
+      lambda_in_dependent_function<decltype(x)>();
+      // CHECK: define internal spir_func void @"_Z28lambda_in_dependent_functionIZZ4mainENK3$_0clEvEUlvE_Evv
+      // CHECK: call spir_func void @printf(i8* getelementptr inbounds ([[DEP_LAMBDA_SIZE]], [[DEP_LAMBDA_SIZE]]* @[[LAMBDA_IN_DEP_X]]
+      
+      lambda_two_dependent_functions<int,double>(3, 5.5);
+      // CHECK: define linkonce_odr spir_func void @_Z30lambda_two_dependent_functionsIidEvT_T0_(i32 %a, double %b)
+      // CHECK: call spir_func void @printf(i8* getelementptr inbounds ([55 x i8], [55 x i8]* @usn_str.13, i32 0, i32 0))
+
+      int a = 5;
+      double b = 10.7; 
+      auto y = [](int a) {return a;};
+      auto z = [](double b) {return b;};
+      //lambda_two_dependent_functions<decltype(y), decltype(z)>(); 
+    });
+}

--- a/clang/test/ParserSYCL/unique_stable_name.cpp
+++ b/clang/test/ParserSYCL/unique_stable_name.cpp
@@ -1,0 +1,33 @@
+// RUN: %clang_cc1 -fsyntax-only -verify -Wno-unused %s
+
+namespace NS{};
+
+void f(int var) {
+  // expected-error@+1{{expected '(' after '__builtin_unique_stable_name'}}
+  __builtin_unique_stable_name int;
+  // expected-error@+1{{expected '(' after '__builtin_unique_stable_name'}}
+  __builtin_unique_stable_name {int};
+
+  __builtin_unique_stable_name(var);
+  // expected-error@+1{{use of undeclared identifier 'bad_var'}}
+  __builtin_unique_stable_name(bad_var);
+  // expected-error@+1{{use of undeclared identifier 'bad'}}
+  __builtin_unique_stable_name(bad::type);
+  // expected-error@+1{{no member named 'still_bad' in namespace 'NS'}}
+  __builtin_unique_stable_name(NS::still_bad);
+}
+
+template <typename T>
+void f2() {
+  // expected-error@+1{{no member named 'bad_val' in 'S'}}
+  __builtin_unique_stable_name(T::bad_val);
+  // expected-error@+1{{no type named 'bad_type' in 'S'}}
+  __builtin_unique_stable_name(typename T::bad_type);
+}
+
+struct S{};
+
+void use() {
+  // expected-note@+1{{in instantiation of}}
+  f2<S>();
+}

--- a/clang/test/ParserSYCL/unique_stable_name.cpp
+++ b/clang/test/ParserSYCL/unique_stable_name.cpp
@@ -21,6 +21,11 @@ void f(int var) {
 
   __builtin_unique_stable_name(var);
   __builtin_unique_stable_name(NS::good);
+
+  // expected-error@+1{{expected expression}}
+  __builtin_unique_stable_name(for (int i = 0; i < 10; ++i) {})
+  __builtin_unique_stable_name({
+    (for (int i = 0; i < 10; ++i){})})
 }
 
 template <typename T>

--- a/clang/test/ParserSYCL/unique_stable_name.cpp
+++ b/clang/test/ParserSYCL/unique_stable_name.cpp
@@ -13,7 +13,7 @@ void f(int var) {
 
   // expected-error@+2{{expected ')'}}
   // expected-note@+1{{to match this '('}}
-  __builtin_unique_stable_name(int; //Missing paren before semicolon
+  __builtin_unique_stable_name(int; // Missing paren before semicolon
 
   // expected-error@+2{{expected ')'}}
   // expected-note@+1{{to match this '('}}

--- a/clang/test/ParserSYCL/unique_stable_name.cpp
+++ b/clang/test/ParserSYCL/unique_stable_name.cpp
@@ -1,33 +1,37 @@
 // RUN: %clang_cc1 -fsyntax-only -verify -Wno-unused %s
 
-namespace NS{};
+namespace NS {
+int good = 55;
+}
 
 void f(int var) {
   // expected-error@+1{{expected '(' after '__builtin_unique_stable_name'}}
-  __builtin_unique_stable_name int;
+  __builtin_unique_stable_name int; // Correct usage is __builtin_unique_stable_name(int);
+
   // expected-error@+1{{expected '(' after '__builtin_unique_stable_name'}}
-  __builtin_unique_stable_name {int};
+  __builtin_unique_stable_name {int}; // Correct usage is __builtin_unique_stable_name(int);
+
+  // expected-error@+2{{expected ')'}}
+  // expected-note@+1{{to match this '('}}
+  __builtin_unique_stable_name(int; //Missing paren before semicolon
+
+  // expected-error@+2{{expected ')'}}
+  // expected-note@+1{{to match this '('}}
+  __builtin_unique_stable_name(int, float); // Missing paren before comma
 
   __builtin_unique_stable_name(var);
-  // expected-error@+1{{use of undeclared identifier 'bad_var'}}
-  __builtin_unique_stable_name(bad_var);
-  // expected-error@+1{{use of undeclared identifier 'bad'}}
-  __builtin_unique_stable_name(bad::type);
-  // expected-error@+1{{no member named 'still_bad' in namespace 'NS'}}
-  __builtin_unique_stable_name(NS::still_bad);
+  __builtin_unique_stable_name(NS::good);
 }
 
 template <typename T>
 void f2() {
-  // expected-error@+1{{no member named 'bad_val' in 'S'}}
-  __builtin_unique_stable_name(T::bad_val);
-  // expected-error@+1{{no type named 'bad_type' in 'S'}}
-  __builtin_unique_stable_name(typename T::bad_type);
+  __builtin_unique_stable_name(typename T::good_type);
 }
 
-struct S{};
+struct S {
+  class good_type {};
+};
 
 void use() {
-  // expected-note@+1{{in instantiation of}}
   f2<S>();
 }

--- a/clang/test/SemaSYCL/unique_stable_name.cpp
+++ b/clang/test/SemaSYCL/unique_stable_name.cpp
@@ -103,10 +103,11 @@ int main() {
   kernel_single_task<class kernel6>(l6); // Used in the kernel name after builtin
 
   // kernel7 - expect error
+  // Same as kernel11 (below) except make the lambda part of naming the kernel.
   // Test that passing a lambda to the unique stable name builtin and then
   // passing a second lambda to the kernel throws an error because the first
-  // lambda is included in the signature of the second lambda, hence attempting
-  // to change the mangling of the kernel
+  // lambda is included in the signature of the second lambda, hence it changes
+  // the mangling of the kernel.
   auto l7 = []() { return 1; };
   auto l8 = [](decltype(l7) *derp = nullptr) { return 2; };
   constexpr const char *l7_output = __builtin_unique_stable_name(l7); // #USN_l7
@@ -136,18 +137,14 @@ int main() {
   }
 
   // kernel11 - expect no error
-  // Make a lambda
-  // Make another lambda that captures the first one
-  // Call the builtin on the first lambda (in a constexpr context)
-  // Pass the second lambda to a kernel
   // Test that passing a lambda to the unique stable name builtin and then
   // passing a second lambda capturing the first one to the kernel does not
   // throw an error because the first lambda is not involved in naming the
-  // kernel i.e., the mangling does not change
+  // kernel i.e., the mangling does not change.
   auto l11 = []() { return 1; };
   auto l12 = [l11]() { return 2; };
   constexpr const char *l11_output = __builtin_unique_stable_name(l11);
-  kernel_single_task<class kernel11>(l12); // #kernel6call
+  kernel_single_task<class kernel11>(l12);
 
   // kernel12 - expect an error
   // Test that passing a lambda to the unique stable name builtin and then

--- a/clang/test/SemaSYCL/unique_stable_name.cpp
+++ b/clang/test/SemaSYCL/unique_stable_name.cpp
@@ -1,36 +1,24 @@
 // RUN: %clang_cc1 %s --std=c++17 -fsyntax-only -fsycl-is-device -Wno-unused -verify
-// RUN: %clang_cc1 %s --std=c++17 -fsyntax-only -DTRIGGER_ERROR -fsycl-is-device -Wno-unused -verify
-
-#ifdef TRIGGER_ERROR
 
 template <typename KernelName, typename KernelType>
-[[clang::sycl_kernel]] void kernel_single_task(KernelType kernelFunc) { // expected-error 6 {{kernel instantiation changes the result of an evaluated '__builtin_unique_stable_name'}}
+[[clang::sycl_kernel]] void kernel_single_task(KernelType kernelFunc) { // #1 #2 #3 #4 #5 #6 #7 #8 #9 #10 #11
   kernelFunc();
 }
 
 template <typename Func>
 void kernel3func(const Func &F3) {
-  // note@+1{{'__builtin_unique_stable_name' evaluated here}}
   constexpr const char *F3_output = __builtin_unique_stable_name(F3);
-  // error@+1{{kernel instantiation changes the result of an evaluated '__builtin_unique_stable_name'}}
+  // expected-error@#8{{kernel instantiation changes the result of an evaluated '__builtin_unique_stable_name'}}
   // expected-note@+1{{in instantiation of function template specialization}}
-  kernel_single_task<class kernel3>(F3);
+  kernel_single_task<class kernel3>(F3); // 8th instantiation throwing error
 }
 
 template <typename Func>
 void kernel4func(const Func &F4) {
-  // note@+1{{'__builtin_unique_stable_name' evaluated here}}
   constexpr const char *F4_output = __builtin_unique_stable_name(F4);
-  // error@+1{{kernel instantiation changes the result of an evaluated '__builtin_unique_stable_name'}}
+  // expected-error@#9{{kernel instantiation changes the result of an evaluated '__builtin_unique_stable_name'}}
   // expected-note@+1{{in instantiation of function template specialization}}
-  kernel_single_task<class kernel4>([]() {});
-}
-
-#else
-// This section is not supposed to emit any diagnostics but there are currently two
-template <typename KernelName, typename KernelType>
-[[clang::sycl_kernel]] void kernel_single_task(KernelType kernelFunc) { // expected-error 2 {{kernel instantiation changes the result of an evaluated '__builtin_unique_stable_name'}}
-  kernelFunc();
+  kernel_single_task<class kernel4>([]() {}); // 9th instantiation throwing error
 }
 
 template <template <typename> typename Outer, typename Inner>
@@ -43,8 +31,13 @@ struct T {};
 
 template <typename Func>
 void kernel13_14func(const Func &F) {
-  kernel_single_task<class kernel13>(F);
-  kernel_single_task<class kernel14>(F); // Using the same functor twice should be fine
+  // expected-error@#10{{kernel instantiation changes the result of an evaluated '__builtin_unique_stable_name'}}
+  // expected-note@+1{{in instantiation of function template specialization}}
+  kernel_single_task<class kernel13>(F); // 10th instantiation throwing error
+  // expected-error@#11{{kernel instantiation changes the result of an evaluated '__builtin_unique_stable_name'}}
+  // expected-note@+1{{in instantiation of function template specialization}}
+  kernel_single_task<class kernel14>(F); // 11th instantiation throwing error
+  // Using the same functor twice should be fine
 }
 
 template <typename Ty>
@@ -61,10 +54,8 @@ static constexpr const char *output1 = __builtin_unique_stable_name(T);
   auto l12 = []() { return 1; }; \
   constexpr const char *l1_output = __builtin_unique_stable_name(l12);
 
-#endif
 int main() {
 
-#ifdef TRIGGER_ERROR
   // kernel0
   // kernel_single_task<class kernel0>(func<Derp>());
 
@@ -76,10 +67,10 @@ int main() {
 
   // kernel2 Call to the builtin on a lambda, then using the lambda for a kernel name
   auto l2 = []() { return 1; };
-  constexpr const char *l2_output = __builtin_unique_stable_name(l2); // expected-note 2 {{'__builtin_unique_stable_name' evaluated here}}
-
+  constexpr const char *l2_output = __builtin_unique_stable_name(l2); // expected-note {{'__builtin_unique_stable_name' evaluated here}}
+  // expected-error@#1{{kernel instantiation changes the result of an evaluated '__builtin_unique_stable_name'}}
   // expected-note@+1{{in instantiation of function template specialization}}
-  kernel_single_task<class kernel2>(l2);
+  kernel_single_task<class kernel2>(l2); // 1st instantiation throwing error
 
   // kernel3
   // The current function is named with a lambda (that is, takes a lambda as a template parameter).  Call the builtin (perhaps on the current function?), then pass it to a kernel.
@@ -94,9 +85,10 @@ int main() {
   // Same as kernel6, except make l6 part of naming kernel
   auto l7 = []() { return 1; };
   auto l8 = [](decltype(l7) *derp = nullptr) { return 2; };
-  constexpr const char *l7_output = __builtin_unique_stable_name(l7); // expected-note 3 {{'__builtin_unique_stable_name' evaluated here}}
+  constexpr const char *l7_output = __builtin_unique_stable_name(l7); // expected-note {{'__builtin_unique_stable_name' evaluated here}}
+  // expected-error@#2{{kernel instantiation changes the result of an evaluated '__builtin_unique_stable_name'}}
   // expected-note@+1{{in instantiation of function template specialization}}
-  kernel_single_task<class kernel7>(l8);
+  kernel_single_task<class kernel7>(l8); // 2nd instantiation throwing error
 
   // kernel8 and kernel9 - expect no error
   // Make two lambdas
@@ -107,18 +99,20 @@ int main() {
   // expected-note@+1{{'__builtin_unique_stable_name' evaluated here}}
   constexpr const char *l10_output = __builtin_unique_stable_name(l10);
   if constexpr (1) {
+    // expected-error@#3{{kernel instantiation changes the result of an evaluated '__builtin_unique_stable_name'}}
     // expected-note@+1{{in instantiation of function template specialization}}
-    kernel_single_task<class kernel8>(l9);
+    kernel_single_task<class kernel8>(l9); // 3rd instantiation throwing
   } else {
+    // expected-error@#4{{kernel instantiation changes the result of an evaluated '__builtin_unique_stable_name'}}
     // expected-note@+1{{in instantiation of function template specialization}}
-    kernel_single_task<class kernel9>(l10);
+    kernel_single_task<class kernel9>(l10); // 4th instantiation throwing error
   }
 
-#else
   // This section is not supposed to emit any diagnostics but currently there are two cases with issues
   //
   // kernel13 and kernel14 - expect no error
-  kernel13_14func([]() {}); // pass the same lambda to two kernels
+  // pass the same lambda to two kernels
+  kernel13_14func([]() {}); // expected-note 2 {{in instantiation of function template specialization}}
 
   // kernel5 - same as kernel11 below?
   // Same as the above two, except the thing in the template parameter/kernel calls are a function object that has a lambda in its template parameters.
@@ -130,8 +124,10 @@ int main() {
   // Pass the second lambda to a kernel
   auto l5 = []() { return 1; };
   auto l6 = [l5]() { return 2; };
-  constexpr const char *l5_output = __builtin_unique_stable_name(l5);
-  kernel_single_task<class kernel6>(l6);
+  constexpr const char *l5_output = __builtin_unique_stable_name(l5); // expected-note {{'__builtin_unique_stable_name' evaluated here}}
+  // expected-error@#5{{kernel instantiation changes the result of an evaluated '__builtin_unique_stable_name'}}
+  // expected-note@+1{{in instantiation of function template specialization}}
+  kernel_single_task<class kernel6>(l6); // 5th instantiation throwing error
 
   // Make a lambda
   // Call the builtin on the first lambda (in a constexpr context)
@@ -139,19 +135,17 @@ int main() {
   auto l11 = []() { return 1; };
   // expected-note@+1{{'__builtin_unique_stable_name' evaluated here}}
   constexpr const char *l11_output = __builtin_unique_stable_name(l11);
+  // expected-error@#6{{kernel instantiation changes the result of an evaluated '__builtin_unique_stable_name'}}
   // expected-note@+1{{in instantiation of function template specialization}}
-  kernel_single_task<class kernel11>(S<T, decltype(l11)>{});
+  kernel_single_task<class kernel11>(S<T, decltype(l11)>{}); // 6th instantiation throwing error
 
-  // expected-note@+1{{in instantiation of function template specialization}}
-  kernel_single_task<class kernel12>(
+  // expected-error@#7{{kernel instantiation changes the result of an evaluated '__builtin_unique_stable_name'}}
+  kernel_single_task<class kernel12>( // 7th instantiation throwing error
       []() {
         // expected-note@+1{{'__builtin_unique_stable_name' evaluated here}}
         MACRO12();
       });
-#endif
 }
-
-#ifdef TRIGGER_ERROR
 
 namespace NS {}
 
@@ -178,4 +172,3 @@ void use() {
   // expected-note@+1{{in instantiation of}}
   f2<St>();
 }
-#endif

--- a/clang/test/SemaSYCL/unique_stable_name.cpp
+++ b/clang/test/SemaSYCL/unique_stable_name.cpp
@@ -1,10 +1,38 @@
-// RUN: %clang_cc1 %s -fsyntax-only -ast-dump -fsycl-is-device -triple spir64 -verify
+// RUN: %clang_cc1 %s --std=c++17 -fsyntax-only -fsycl-is-device -Wno-unused -verify
+// RUN: %clang_cc1 %s --std=c++17 -fsyntax-only -DTRIGGER_ERROR -fsycl-is-device -Wno-unused -verify
 
-// expected-error 8 @+2{{kernel instantiation changes the result of an evaluated __builtin_unique_stable_name}}
+#ifdef TRIGGER_ERROR
+
 template <typename KernelName, typename KernelType>
-[[clang::sycl_kernel]] void kernel_single_task(KernelType kernelFunc) {
+[[clang::sycl_kernel]] void kernel_single_task(KernelType kernelFunc) { // expected-error 6 {{kernel instantiation changes the result of an evaluated '__builtin_unique_stable_name'}}
   kernelFunc();
 }
+
+template <typename Func>
+void kernel3func(const Func &F3) {
+  // note@+1{{'__builtin_unique_stable_name' evaluated here}}
+  constexpr const char *F3_output = __builtin_unique_stable_name(F3);
+  // error@+1{{kernel instantiation changes the result of an evaluated '__builtin_unique_stable_name'}}
+  // expected-note@+1{{in instantiation of function template specialization}}
+  kernel_single_task<class kernel3>(F3);
+}
+
+template <typename Func>
+void kernel4func(const Func &F4) {
+  // note@+1{{'__builtin_unique_stable_name' evaluated here}}
+  constexpr const char *F4_output = __builtin_unique_stable_name(F4);
+  // error@+1{{kernel instantiation changes the result of an evaluated '__builtin_unique_stable_name'}}
+  // expected-note@+1{{in instantiation of function template specialization}}
+  kernel_single_task<class kernel4>([]() {});
+}
+
+#else
+// This section is not supposed to emit any diagnostics but there are currently two
+template <typename KernelName, typename KernelType>
+[[clang::sycl_kernel]] void kernel_single_task(KernelType kernelFunc) { // expected-error 2 {{kernel instantiation changes the result of an evaluated '__builtin_unique_stable_name'}}
+  kernelFunc();
+}
+
 template <template <typename> typename Outer, typename Inner>
 struct S {
   void operator()() const;
@@ -12,22 +40,6 @@ struct S {
 
 template <typename Ty>
 struct T {};
-
-template <typename Func>
-void kernel3func(const Func &F3) {
-  // expected-note@+1{{__builtin_unique_stable_name evaluated here}}
-  constexpr const char *F3_output = __builtin_unique_stable_name(F3);
-  // expected-error@+1{{error: kernel instantiation changes the result of an evaluated __builtin_unique_stable_name}}
-  kernel_single_task<class kernel3>(F3);
-}
-
-template <typename Func>
-void kernel4func(const Func &F4) {
-  // expected-note@+1{{__builtin_unique_stable_name evaluated here}}
-  constexpr const char *F4_output = __builtin_unique_stable_name(F4);
-  // expected-error@+1{{error: kernel instantiation changes the result of an evaluated __builtin_unique_stable_name}}
-  kernel_single_task<class kernel4>([]() {});
-}
 
 template <typename Func>
 void kernel13_14func(const Func &F) {
@@ -49,12 +61,12 @@ static constexpr const char *output1 = __builtin_unique_stable_name(T);
   auto l12 = []() { return 1; }; \
   constexpr const char *l1_output = __builtin_unique_stable_name(l12);
 
+#endif
 int main() {
+
+#ifdef TRIGGER_ERROR
   // kernel0
-  kernel_single_task<class kernel0>( // func<Derp>());
-      []() {
-        func<Derp>();
-      });
+  // kernel_single_task<class kernel0>(func<Derp>());
 
   // kernel1 Evaluate the builtin in a constant context, then call the kernel with that same type
   auto l1 = []() {};
@@ -64,18 +76,47 @@ int main() {
 
   // kernel2 Call to the builtin on a lambda, then using the lambda for a kernel name
   auto l2 = []() { return 1; };
-  // expected-note@+1{{__builtin_unique_stable_name evaluated here}}
-  constexpr const char *l2_output = __builtin_unique_stable_name(l2);
-  // expected-error@+1{{error: kernel instantiation changes the result of an evaluated __builtin_unique_stable_name}}
+  constexpr const char *l2_output = __builtin_unique_stable_name(l2); // expected-note 2 {{'__builtin_unique_stable_name' evaluated here}}
+
+  // expected-note@+1{{in instantiation of function template specialization}}
   kernel_single_task<class kernel2>(l2);
 
   // kernel3
   // The current function is named with a lambda (that is, takes a lambda as a template parameter).  Call the builtin (perhaps on the current function?), then pass it to a kernel.
+  // expected-note@+1{{in instantiation of function template specialization}}
   kernel3func([]() {});
 
   // kernel4 Same as above, but you use a NEW lambda defined inline to name the kernel.
+  // expected-note@+1{{in instantiation of function template specialization}}
   kernel4func([]() {});
 
+  // kernel7 - expect error
+  // Same as kernel6, except make l6 part of naming kernel
+  auto l7 = []() { return 1; };
+  auto l8 = [](decltype(l7) *derp = nullptr) { return 2; };
+  constexpr const char *l7_output = __builtin_unique_stable_name(l7); // expected-note 3 {{'__builtin_unique_stable_name' evaluated here}}
+  // expected-note@+1{{in instantiation of function template specialization}}
+  kernel_single_task<class kernel7>(l8);
+
+  // kernel8 and kernel9 - expect no error
+  // Make two lambdas
+  // Call the builtin on the second of the two lambdas (in a constexpr context)
+  // Within a constexpr if, pass the first lambda to a kernel in the true branch, pass the second lambda to a kernel in the false branch
+  auto l9 = []() { return 1; };
+  auto l10 = []() { return 2; };
+  // expected-note@+1{{'__builtin_unique_stable_name' evaluated here}}
+  constexpr const char *l10_output = __builtin_unique_stable_name(l10);
+  if constexpr (1) {
+    // expected-note@+1{{in instantiation of function template specialization}}
+    kernel_single_task<class kernel8>(l9);
+  } else {
+    // expected-note@+1{{in instantiation of function template specialization}}
+    kernel_single_task<class kernel9>(l10);
+  }
+
+#else
+  // This section is not supposed to emit any diagnostics but currently there are two cases with issues
+  //
   // kernel13 and kernel14 - expect no error
   kernel13_14func([]() {}); // pass the same lambda to two kernels
 
@@ -92,39 +133,49 @@ int main() {
   constexpr const char *l5_output = __builtin_unique_stable_name(l5);
   kernel_single_task<class kernel6>(l6);
 
-  // kernel7 - expect error
-  // Same as kernel6, except make l6 part of naming kernel
-  auto l7 = []() { return 1; };
-  auto l8 = [](decltype(l7) *derp = nullptr) { return 2; };
-  // expected-note@+1{{__builtin_unique_stable_name evaluated here}}
-  constexpr const char *l7_output = __builtin_unique_stable_name(l7);
-  // expected-error@+1{{kernel instantiation changes the result of an evaluated __builtin_unique_stable_name}}
-  kernel_single_task<class kernel7>(l8);
-
-  // kernel8 and kernel9 - expect no error
-  // Make two lambdas
-  // Call the builtin on the second of the two lambdas (in a constexpr context)
-  // Within a constexpr if, pass the first lambda to a kernel in the true branch, pass the second lambda to a kernel in the false branch
-  auto l9 = []() { return 1; };
-  auto l10 = []() { return 2; };
-  // expected-note@+1{{'__builtin_unique_stable_name' evaluated here}}
-  constexpr const char *l10_output = __builtin_unique_stable_name(l10);
-  if constexpr (1) {
-    kernel_single_task<class kernel8>(l9);
-  } else {
-    // expected-note@+1{{in instantiation of function template specialization}}
-    kernel_single_task<class kernel9>(l10);
-  }
   // Make a lambda
   // Call the builtin on the first lambda (in a constexpr context)
   // Pass the lambda as a template template parameter to a kernel
   auto l11 = []() { return 1; };
+  // expected-note@+1{{'__builtin_unique_stable_name' evaluated here}}
   constexpr const char *l11_output = __builtin_unique_stable_name(l11);
+  // expected-note@+1{{in instantiation of function template specialization}}
   kernel_single_task<class kernel11>(S<T, decltype(l11)>{});
 
+  // expected-note@+1{{in instantiation of function template specialization}}
   kernel_single_task<class kernel12>(
       []() {
-        // expected-error@+1{{kernel instantiation changes the result of an evaluated __builtin_unique_stable_name}}
+        // expected-note@+1{{'__builtin_unique_stable_name' evaluated here}}
         MACRO12();
       });
+#endif
 }
+
+#ifdef TRIGGER_ERROR
+
+namespace NS {}
+
+void f() {
+  // expected-error@+1{{use of undeclared identifier 'bad_var'}}
+  __builtin_unique_stable_name(bad_var);
+  // expected-error@+1{{use of undeclared identifier 'bad'}}
+  __builtin_unique_stable_name(bad::type);
+  // expected-error@+1{{no member named 'still_bad' in namespace 'NS'}}
+  __builtin_unique_stable_name(NS::still_bad);
+}
+
+template <typename T>
+void f2() {
+  // expected-error@+1{{no member named 'bad_val' in 'St'}}
+  __builtin_unique_stable_name(T::bad_val);
+  // expected-error@+1{{no type named 'bad_type' in 'St'}}
+  __builtin_unique_stable_name(typename T::bad_type);
+}
+
+struct St {};
+
+void use() {
+  // expected-note@+1{{in instantiation of}}
+  f2<St>();
+}
+#endif

--- a/clang/test/SemaSYCL/unique_stable_name.cpp
+++ b/clang/test/SemaSYCL/unique_stable_name.cpp
@@ -5,6 +5,14 @@ template <typename KernelName, typename KernelType>
   kernelFunc();
 }
 
+// kernel3 - expect error
+// The current function is named with a lambda (i.e., takes a lambda as a
+// template parameter. Call the builtin on the current function
+// Then it is passed to kernel
+// Error is thrown because the current function is passed to the kernel,
+// thus part of the latter's name, after its unique stable is already computed
+// Current function is a part of that name, causing its unique_stable_name
+// mangling to change
 template <typename Func>
 void kernel3func(const Func &F3) {
   // expected-note@+1{{'__builtin_unique_stable_name' evaluated here}}
@@ -15,7 +23,13 @@ void kernel3func(const Func &F3) {
   kernel_single_task<class kernel3>(F3);
 }
 
-//
+// kernel4 - expect error
+// The current function is named with a lambda (i.e., takes a lambda as a
+// template parameter. Call the builtin on the current function
+// Then an empty lambda is passed to kernel
+// Error is thrown because the empty lambda is named based on kernel4func
+// Current function is a part of that name, causing its unique_stable_name
+// mangling to change
 template <typename Func>
 void kernel4func(const Func &F4) {
   // expected-error@#kernelSingleTask{{kernel instantiation changes the result of an evaluated '__builtin_unique_stable_name'}}
@@ -82,20 +96,11 @@ int main() {
   kernel_single_task<class kernel2>(l2);
 
   // kernel3 - expect error
-  // The current function is named with a lambda (that is, takes a lambda as a
-  // template parameter). Call the builtin on the current function
-  // Then current function is passed to kernel
   // expected-note@#USN_l7{{'__builtin_unique_stable_name' evaluated here}}
   // expected-note@+1{{in instantiation of function template specialization}}
   kernel3func([]() {}); // #kernel3func_call
 
   // kernel4 - expect error
-  // The current function is named with a lambda (i.e., takes a lambda as a
-  // template parameter. Call the builtin on the current function
-  // Then an empty lambda is passed to kernel
-  // Error is thrown because the empty lambda is named based on kernel4func
-  // Current function is a part of that name, causing its unique_stable_name
-  // mangling to change
   // expected-note@+1{{in instantiation of function template specialization}}
   kernel4func([]() {});
 
@@ -140,10 +145,6 @@ int main() {
   // kernel13 and kernel14 - expect no error
   // pass the same lambda to two kernels
   kernel13_14func([]() {}); // #kernel13_14func_call expected-note {{in instantiation of function template specialization}}
-
-  // kernel5 - same as kernel11 below?
-  // Same as the above two, except the thing in the template parameter
-  // kernel calls are a function object that has a lambda in its template parameters.
 
   // kernel6 - expect no error
   // Make a lambda

--- a/clang/test/SemaSYCL/unique_stable_name.cpp
+++ b/clang/test/SemaSYCL/unique_stable_name.cpp
@@ -1,24 +1,24 @@
 // RUN: %clang_cc1 %s --std=c++17 -fsyntax-only -fsycl-is-device -Wno-unused -verify
 
 template <typename KernelName, typename KernelType>
-[[clang::sycl_kernel]] void kernel_single_task(KernelType kernelFunc) { // #1 #2 #3 #4 #5 #6 #7 #8 #9 #10 #11
+[[clang::sycl_kernel]] void kernel_single_task(KernelType kernelFunc) { // #kernelSingleTask
   kernelFunc();
 }
 
 template <typename Func>
 void kernel3func(const Func &F3) {
   constexpr const char *F3_output = __builtin_unique_stable_name(F3);
-  // expected-error@#8{{kernel instantiation changes the result of an evaluated '__builtin_unique_stable_name'}}
+  // expected-error@#kernelSingleTask{{kernel instantiation changes the result of an evaluated '__builtin_unique_stable_name'}}
   // expected-note@+1{{in instantiation of function template specialization}}
-  kernel_single_task<class kernel3>(F3); // 8th instantiation throwing error
+  kernel_single_task<class kernel3>(F3);
 }
 
 template <typename Func>
 void kernel4func(const Func &F4) {
   constexpr const char *F4_output = __builtin_unique_stable_name(F4);
-  // expected-error@#9{{kernel instantiation changes the result of an evaluated '__builtin_unique_stable_name'}}
+  // expected-error@#kernelSingleTask{{kernel instantiation changes the result of an evaluated '__builtin_unique_stable_name'}}
   // expected-note@+1{{in instantiation of function template specialization}}
-  kernel_single_task<class kernel4>([]() {}); // 9th instantiation throwing error
+  kernel_single_task<class kernel4>([]() {});
 }
 
 template <template <typename> typename Outer, typename Inner>
@@ -31,12 +31,12 @@ struct T {};
 
 template <typename Func>
 void kernel13_14func(const Func &F) {
-  // expected-error@#10{{kernel instantiation changes the result of an evaluated '__builtin_unique_stable_name'}}
+  // expected-error@#kernelSingleTask{{kernel instantiation changes the result of an evaluated '__builtin_unique_stable_name'}}
   // expected-note@+1{{in instantiation of function template specialization}}
-  kernel_single_task<class kernel13>(F); // 10th instantiation throwing error
-  // expected-error@#11{{kernel instantiation changes the result of an evaluated '__builtin_unique_stable_name'}}
+  kernel_single_task<class kernel13>(F);
+  // expected-error@#kernelSingleTask{{kernel instantiation changes the result of an evaluated '__builtin_unique_stable_name'}}
   // expected-note@+1{{in instantiation of function template specialization}}
-  kernel_single_task<class kernel14>(F); // 11th instantiation throwing error
+  kernel_single_task<class kernel14>(F);
   // Using the same functor twice should be fine
 }
 
@@ -59,7 +59,8 @@ int main() {
   // kernel0
   // kernel_single_task<class kernel0>(func<Derp>());
 
-  // kernel1 Evaluate the builtin in a constant context, then call the kernel with that same type
+  // kernel1 Evaluate the builtin in a constant context, then call the kernel 
+  // with that same type
   auto l1 = []() {};
   constexpr const char *l1_output = __builtin_unique_stable_name(l1);
   kernel_single_task<class kernel1>(
@@ -67,13 +68,15 @@ int main() {
 
   // kernel2 Call to the builtin on a lambda, then using the lambda for a kernel name
   auto l2 = []() { return 1; };
-  constexpr const char *l2_output = __builtin_unique_stable_name(l2); // expected-note {{'__builtin_unique_stable_name' evaluated here}}
-  // expected-error@#1{{kernel instantiation changes the result of an evaluated '__builtin_unique_stable_name'}}
+  constexpr const char *l2_output = __builtin_unique_stable_name(l2); // expected-note 2 {{'__builtin_unique_stable_name' evaluated here}}
+  // expected-error@#kernelSingleTask{{kernel instantiation changes the result of an evaluated '__builtin_unique_stable_name'}}
   // expected-note@+1{{in instantiation of function template specialization}}
   kernel_single_task<class kernel2>(l2); // 1st instantiation throwing error
 
   // kernel3
-  // The current function is named with a lambda (that is, takes a lambda as a template parameter).  Call the builtin (perhaps on the current function?), then pass it to a kernel.
+  // The current function is named with a lambda (that is, takes a lambda as a 
+  // template parameter).  Call the builtin (perhaps on the current function?)
+  // then pass it to a kernel.
   // expected-note@+1{{in instantiation of function template specialization}}
   kernel3func([]() {});
 
@@ -85,37 +88,39 @@ int main() {
   // Same as kernel6, except make l6 part of naming kernel
   auto l7 = []() { return 1; };
   auto l8 = [](decltype(l7) *derp = nullptr) { return 2; };
-  constexpr const char *l7_output = __builtin_unique_stable_name(l7); // expected-note {{'__builtin_unique_stable_name' evaluated here}}
-  // expected-error@#2{{kernel instantiation changes the result of an evaluated '__builtin_unique_stable_name'}}
+  constexpr const char *l7_output = __builtin_unique_stable_name(l7); // expected-note 3 {{'__builtin_unique_stable_name' evaluated here}}
+  // expected-error@#kernelSingleTask{{kernel instantiation changes the result of an evaluated '__builtin_unique_stable_name'}}
   // expected-note@+1{{in instantiation of function template specialization}}
-  kernel_single_task<class kernel7>(l8); // 2nd instantiation throwing error
+  kernel_single_task<class kernel7>(l8);
 
   // kernel8 and kernel9 - expect no error
   // Make two lambdas
   // Call the builtin on the second of the two lambdas (in a constexpr context)
-  // Within a constexpr if, pass the first lambda to a kernel in the true branch, pass the second lambda to a kernel in the false branch
+  // Within a constexpr if, pass the first lambda to a kernel in the true branch,
+  // pass the second lambda to a kernel in the false branch
   auto l9 = []() { return 1; };
   auto l10 = []() { return 2; };
-  // expected-note@+1{{'__builtin_unique_stable_name' evaluated here}}
-  constexpr const char *l10_output = __builtin_unique_stable_name(l10);
+  constexpr const char *l10_output = __builtin_unique_stable_name(l10); // expected-note 2 {{'__builtin_unique_stable_name' evaluated here}}
   if constexpr (1) {
-    // expected-error@#3{{kernel instantiation changes the result of an evaluated '__builtin_unique_stable_name'}}
+    // expected-error@#kernelSingleTask{{kernel instantiation changes the result of an evaluated '__builtin_unique_stable_name'}}
     // expected-note@+1{{in instantiation of function template specialization}}
-    kernel_single_task<class kernel8>(l9); // 3rd instantiation throwing
+    kernel_single_task<class kernel8>(l9);
   } else {
-    // expected-error@#4{{kernel instantiation changes the result of an evaluated '__builtin_unique_stable_name'}}
+    // expected-error@#kernelSingleTask{{kernel instantiation changes the result of an evaluated '__builtin_unique_stable_name'}}
     // expected-note@+1{{in instantiation of function template specialization}}
-    kernel_single_task<class kernel9>(l10); // 4th instantiation throwing error
+    kernel_single_task<class kernel9>(l10);
   }
 
-  // This section is not supposed to emit any diagnostics but currently there are two cases with issues
+  // This section is not supposed to emit any diagnostics but currently there 
+  // are two cases with issues
   //
   // kernel13 and kernel14 - expect no error
   // pass the same lambda to two kernels
   kernel13_14func([]() {}); // expected-note 2 {{in instantiation of function template specialization}}
 
   // kernel5 - same as kernel11 below?
-  // Same as the above two, except the thing in the template parameter/kernel calls are a function object that has a lambda in its template parameters.
+  // Same as the above two, except the thing in the template parameter
+  // kernel calls are a function object that has a lambda in its template parameters.
 
   // kernel6 - expect no error
   // Make a lambda
@@ -124,22 +129,20 @@ int main() {
   // Pass the second lambda to a kernel
   auto l5 = []() { return 1; };
   auto l6 = [l5]() { return 2; };
-  constexpr const char *l5_output = __builtin_unique_stable_name(l5); // expected-note {{'__builtin_unique_stable_name' evaluated here}}
-  // expected-error@#5{{kernel instantiation changes the result of an evaluated '__builtin_unique_stable_name'}}
-  // expected-note@+1{{in instantiation of function template specialization}}
-  kernel_single_task<class kernel6>(l6); // 5th instantiation throwing error
+  constexpr const char *l5_output = __builtin_unique_stable_name(l5);
+  kernel_single_task<class kernel6>(l6);
 
   // Make a lambda
   // Call the builtin on the first lambda (in a constexpr context)
   // Pass the lambda as a template template parameter to a kernel
   auto l11 = []() { return 1; };
-  // expected-note@+1{{'__builtin_unique_stable_name' evaluated here}}
-  constexpr const char *l11_output = __builtin_unique_stable_name(l11);
-  // expected-error@#6{{kernel instantiation changes the result of an evaluated '__builtin_unique_stable_name'}}
+  constexpr const char *l11_output = __builtin_unique_stable_name(l11); // expected-note 2 {{'__builtin_unique_stable_name' evaluated here}}
+  // expected-error@#kernelSingleTask{{kernel instantiation changes the result of an evaluated '__builtin_unique_stable_name'}}
   // expected-note@+1{{in instantiation of function template specialization}}
-  kernel_single_task<class kernel11>(S<T, decltype(l11)>{}); // 6th instantiation throwing error
+  kernel_single_task<class kernel11>(S<T, decltype(l11)>{});
 
-  // expected-error@#7{{kernel instantiation changes the result of an evaluated '__builtin_unique_stable_name'}}
+  // expected-error@#kernelSingleTask{{kernel instantiation changes the result of an evaluated '__builtin_unique_stable_name'}}
+  // expected-note@+1{{in instantiation of function template specialization}}
   kernel_single_task<class kernel12>( // 7th instantiation throwing error
       []() {
         // expected-note@+1{{'__builtin_unique_stable_name' evaluated here}}

--- a/clang/test/SemaSYCL/unique_stable_name.cpp
+++ b/clang/test/SemaSYCL/unique_stable_name.cpp
@@ -1,0 +1,110 @@
+// RUN: %clang_cc1 %s -fsyntax-only -ast-dump -fsycl-is-device -triple spir64 -verify
+
+// expected-error@+2{{kernel instantiation changes the result of an evaluated __builtin_unique_stable_name}}
+template <typename KernelName, typename KernelType>
+[[clang::sycl_kernel]] void kernel_single_task(KernelType kernelFunc) {
+  kernelFunc();
+}
+template <template <typename> typename Outer, typename Inner>
+struct S {
+  void operator()() const;
+  //SYCL_EXTERNAL void operator()() const;
+};
+
+template <typename Ty>
+struct T {};
+
+template <typename Func>
+void kernel3func(const Func &F3) {
+  // expected-note@+1{{__builtin_unique_stable_name evaluated here}}
+  constexpr const char *F3_output = __builtin_unique_stable_name(F3);
+  // expected-error@+1{{error: kernel instantiation changes the result of an evaluated __builtin_unique_stable_name}}
+  kernel_single_task<class kernel3>(F3);
+}
+
+template <typename Func>
+void kernel4func(const Func &F4) {
+  // expected-note@+1{{__builtin_unique_stable_name evaluated here}}
+  constexpr const char *F4_output = __builtin_unique_stable_name(F4);
+  // expected-error@+1{{error: kernel instantiation changes the result of an evaluated __builtin_unique_stable_name}}
+  kernel_single_task<class kernel4>([](){});
+}
+
+template <typename Ty>
+auto func() -> decltype(__builtin_unique_stable_name(Ty::str));
+
+struct Derp {
+  static constexpr const char str[] = "derp derp derp";
+};
+
+template <typename T>
+static constexpr const char *output1 = __builtin_unique_stable_name(T);
+
+int main() {
+  // kernel0  
+  kernel_single_task<class kernel0>(func<Derp>());
+     // []() {
+     //   func<Derp>;
+     // });
+
+  // kernel1 Evaluate the builtin in a constant context, then call the kernel with that same type
+  auto l1 = []() {};
+  constexpr const char *l1_output = __builtin_unique_stable_name(l1);
+  kernel_single_task<class kernel1>(
+      [=]() { l1(); });
+
+  // kernel2 Call to the builtin on a lambda, then using the lambda for a kernel name
+  auto l2 = []() { return 1; };
+  // expected-note@+1{{__builtin_unique_stable_name evaluated here}}
+  constexpr const char *l2_output = __builtin_unique_stable_name(l2);
+  // expected-error@+1{{error: kernel instantiation changes the result of an evaluated __builtin_unique_stable_name}}
+  kernel_single_task<class kernel2>(l2);
+
+  // kernel3
+  // The current function is named with a lambda (that is, takes a lambda as a template parameter).  Call the builtin (perhaps on the current function?), then pass it to a kernel.
+  kernel3func([](){});
+
+  // kernel4 Same as above, but you use a NEW lambda defined inline to name the kernel.
+  kernel4func([](){});
+
+  // kernel5 - same as kernel11 below?
+  // Same as the above two, except the thing in the template parameter/kernel calls are a function object that has a lambda in its template parameters.
+
+  // kernel6 - expect no error
+  // Make a lambda
+  // Make another lambda that captures the first one
+  // Call the builtin on the first lambda (in a constexpr context)
+  // Pass the second lambda to a kernel
+  auto l5 = []() { return 1; };
+  auto l6 = [l5]() { return 2; };
+  constexpr const char *l5_output = __builtin_unique_stable_name(l5);
+  kernel_single_task<class kernel6>(l6);
+
+  // kernel7 - expect error
+  // Same as kernel6, except make l6 part of naming kernel
+  auto l7 = []() { return 1; };
+  auto l8 = [](decltype(l7) *derp = nullptr) { return 2; };
+  // expected-note@+1{{__builtin_unique_stable_name evaluated here}}
+  constexpr const char *l7_output = __builtin_unique_stable_name(l7);
+  // expected-error@+1{{kernel instantiation changes the result of an evaluated __builtin_unique_stable_name}}
+  kernel_single_task<class kernel7>(l8);
+
+  // kernel8 and kernel9 - expect no error
+  // Make two lambdas
+  // Call the builtin on the second of the two lambdas (in a constexpr context)
+  // Within a constexpr if, pass the first lambda to a kernel in the true branch, pass the second lambda to a kernel in the false branch
+  auto l9 = []() { return 1; };
+  auto l10 = []() { return 2; };
+  constexpr const char *l10_output = __builtin_unique_stable_name(l10);
+  if constexpr (1)
+    kernel_single_task<class kernel8>(l9);
+  else
+    kernel_single_task<class kernel9>(l10);
+
+  // Make a lambda
+  // Call the builtin on the first lambda (in a constexpr context)
+  // Pass the lambda as a template template parameter to a kernel
+  auto l11 = []() { return 1; };
+  constexpr const char *l11_output = __builtin_unique_stable_name(l11);
+  kernel_single_task<class kernel12>(S<T, decltype(l11)>{});
+}

--- a/clang/test/SemaSYCL/unique_stable_name.cpp
+++ b/clang/test/SemaSYCL/unique_stable_name.cpp
@@ -6,47 +6,47 @@ template <typename KernelName, typename KernelType>
   kernelFunc();
 }
 
-// kernel3 - expect error
+// kernel1 - expect error
 // The current function is named with a lambda (i.e., takes a lambda as a
 // template parameter. Call the builtin on the current function then it is
 // passed to a kernel. Test that passing the given function to the unique
 // stable name builtin and then to the kernel throws an error because the
 // latter causes its name mangling to change.
 template <typename Func>
-void kernel3func(const Func &F3) {
-  constexpr const char *F3_output = __builtin_unique_stable_name(F3); // #USN_F3
+void kernel1func(const Func &F1) {
+  constexpr const char *F1_output = __builtin_unique_stable_name(F1); // #USN_F1
   // expected-error@#kernelSingleTask{{kernel instantiation changes the result of an evaluated '__builtin_unique_stable_name'}}
-  // expected-note@#kernel3func_call{{in instantiation of function template specialization}}
-  // expected-note@#USN_F3{{'__builtin_unique_stable_name' evaluated here}}
+  // expected-note@#kernel1func_call{{in instantiation of function template specialization}}
+  // expected-note@#USN_F1{{'__builtin_unique_stable_name' evaluated here}}
   // expected-note@+1{{in instantiation of function template specialization}}
-  kernel_single_task<class kernel3>(F3); // #kernel3_call
+  kernel_single_task<class kernel1>(F1); // #kernel1_call
 }
 
-void callkernel3() {
-  kernel3func([]() {}); // #kernel3func_call
+void callkernel1() {
+  kernel1func([]() {}); // #kernel1func_call
 }
 
-// kernel4 - expect error
+// kernel2 - expect error
 // The current function is named with a lambda (i.e., takes a lambda as a
 // template parameter). Call the builtin on the given function,
 // then an empty lambda is passed to kernel.
 // Test that passing the given function to the unique stable name builtin and
 // then passing a different lambda to the kernel still throws an error because
 // the calling context is part of naming the kernel. Even though the given
-// function (F4) is not passed to the kernel, its mangling changes due to
+// function (F2) is not passed to the kernel, its mangling changes due to
 // kernel call with the unrelated lambda.
 template <typename Func>
-void kernel4func(const Func &F4) {
-  constexpr const char *F4_output = __builtin_unique_stable_name(F4); // #USN_F4
+void kernel2func(const Func &F2) {
+  constexpr const char *F2_output = __builtin_unique_stable_name(F2); // #USN_F2
   // expected-error@#kernelSingleTask{{kernel instantiation changes the result of an evaluated '__builtin_unique_stable_name'}}
-  // expected-note@#kernel4func_call{{in instantiation of function template specialization}}
-  // expected-note@#USN_F4{{'__builtin_unique_stable_name' evaluated here}}
+  // expected-note@#kernel2func_call{{in instantiation of function template specialization}}
+  // expected-note@#USN_F2{{'__builtin_unique_stable_name' evaluated here}}
   // expected-note@+1{{in instantiation of function template specialization}}
-  kernel_single_task<class kernel4>([]() {});
+  kernel_single_task<class kernel2>([]() {});
 }
 
-void callkernel4() {
-  kernel4func([]() {}); // #kernel4func_call
+void callkernel2() {
+  kernel2func([]() {}); // #kernel2func_call
 }
 
 template <template <typename> typename Outer, typename Inner>
@@ -58,49 +58,49 @@ template <typename Ty>
 struct Tangerine {};
 
 template <typename Func>
-void kernel13_14func(const Func &F) {
+void kernel3_4func(const Func &F) {
   // Test that passing the same lambda to two kernels does not cause an error
   // because the kernel uses do not interfere with each other or invalidate
   // the stable name in any way.
-  kernel_single_task<class kernel13>(F);
-  kernel_single_task<class kernel14>(F);
+  kernel_single_task<class kernel3>(F);
+  kernel_single_task<class kernel4>(F);
   // Using the same functor twice should be fine
 }
 
-// kernel13 and kernel14 - expect no errors
-void callkernel13_14() {
-  kernel13_14func([]() {});
+// kernel3 and kernel4 - expect no errors
+void callkernel3_4() {
+  kernel3_4func([]() {});
 }
 
 template <typename T>
 static constexpr const char *output1 = __builtin_unique_stable_name(T);
 
-#define MACRO12()                \
-  auto l12 = []() { return 1; }; \
-  constexpr const char *l1_output = __builtin_unique_stable_name(l12);
+#define MACRO()                  \
+  auto l14 = []() { return 1; }; \
+  constexpr const char *l14_output = __builtin_unique_stable_name(l14);
 
 int main() {
 
-  // kernel1 - expect no error
+  // kernel5 - expect no error
   // Test that passing the lambda to the unique stable name builtin and then
   // using the lambda in a way that does not  contribute to the kernel name
   // does not cause an error because the  stable name is not invalidated in
   // this situation.
-  auto l1 = []() {};
-  constexpr const char *l1_output = __builtin_unique_stable_name(l1);
-  kernel_single_task<class kernel1>(
-      [=]() { l1(); }); // Used in the kernel, but not the kernel name itself
+  auto l5 = []() {};
+  constexpr const char *l5_output = __builtin_unique_stable_name(l5);
+  kernel_single_task<class kernel5>(
+      [=]() { l5(); }); // Used in the kernel, but not the kernel name itself
 
-  // kernel2 - expect error
+  // kernel6 - expect error
   // Test that passing the lambda to the unique stable name builtin and then
   // using the same lambda in the naming of a kernel causes a diagnostic on the
   // kernel use due to the change in results to the stable name.
-  auto l2 = []() { return 1; };
-  constexpr const char *l2_output = __builtin_unique_stable_name(l2); // #USN_L2
+  auto l6 = []() { return 1; };
+  constexpr const char *l6_output = __builtin_unique_stable_name(l6); // #USN_l6
   // expected-error@#kernelSingleTask{{kernel instantiation changes the result of an evaluated '__builtin_unique_stable_name'}}
-  // expected-note@#USN_L2{{'__builtin_unique_stable_name' evaluated here}}
+  // expected-note@#USN_l6{{'__builtin_unique_stable_name' evaluated here}}
   // expected-note@+1{{in instantiation of function template specialization}}
-  kernel_single_task<class kernel2>(l2); // Used in the kernel name after builtin
+  kernel_single_task<class kernel6>(l6); // Used in the kernel name after builtin
 
   // kernel7 - expect error
   // Test that passing a lambda to the unique stable name builtin and then
@@ -135,7 +135,7 @@ int main() {
     kernel_single_task<class kernel9>(l10);
   }
 
-  // kernel6 - expect no error
+  // kernel11 - expect no error
   // Make a lambda
   // Make another lambda that captures the first one
   // Call the builtin on the first lambda (in a constexpr context)
@@ -144,33 +144,33 @@ int main() {
   // passing a second lambda capturing the first one to the kernel does not
   // throw an error because the first lambda is not involved in naming the
   // kernel i.e., the mangling does not change
-  auto l5 = []() { return 1; };
-  auto l6 = [l5]() { return 2; };
-  constexpr const char *l5_output = __builtin_unique_stable_name(l5);
-  kernel_single_task<class kernel6>(l6); // #kernel6call
+  auto l11 = []() { return 1; };
+  auto l12 = [l11]() { return 2; };
+  constexpr const char *l11_output = __builtin_unique_stable_name(l11);
+  kernel_single_task<class kernel11>(l12); // #kernel6call
 
-  // kernel11 - expect an error
+  // kernel12 - expect an error
   // Test that passing a lambda to the unique stable name builtin and then
   // passing it to the kernel as a template template parameter causes a
   // diagnostic on the kernel use due to template template parameter being
   // involved in the mangling of the kernel name.
-  auto l11 = []() { return 1; };
-  constexpr const char *l11_output = __builtin_unique_stable_name(l11); // #USN_l11
+  auto l13 = []() { return 1; };
+  constexpr const char *l13_output = __builtin_unique_stable_name(l13); // #USN_l13
   // expected-error@#kernelSingleTask{{kernel instantiation changes the result of an evaluated '__builtin_unique_stable_name'}}
-  // expected-note@#USN_l11{{'__builtin_unique_stable_name' evaluated here}}
+  // expected-note@#USN_l13{{'__builtin_unique_stable_name' evaluated here}}
   // expected-note@+1{{in instantiation of function template specialization}}
-  kernel_single_task<class kernel11>(S<Tangerine, decltype(l11)>{});
+  kernel_single_task<class kernel12>(S<Tangerine, decltype(l13)>{});
 
-  // kernel12 - expect an error
+  // kernel13 - expect an error
   // Test that passing a lambda to the unique stable name builtin within a macro
   // and then calling the macro within the kernel causes an error on the kernel
   // and diagnoses in all the expected places despite the use of a macro.
   // expected-error@#kernelSingleTask{{kernel instantiation changes the result of an evaluated '__builtin_unique_stable_name'}}
-  // expected-note@#USN_MACRO12{{'__builtin_unique_stable_name' evaluated here}}
+  // expected-note@#USN_MACRO{{'__builtin_unique_stable_name' evaluated here}}
   // expected-note@+1{{in instantiation of function template specialization}}
-  kernel_single_task<class kernel12>(
+  kernel_single_task<class kernel13>(
       []() {
-        MACRO12(); // #USN_MACRO12
+        MACRO(); // #USN_MACRO
       });
 }
 

--- a/clang/test/SemaSYCL/unique_stable_name.cpp
+++ b/clang/test/SemaSYCL/unique_stable_name.cpp
@@ -113,17 +113,16 @@ int main() {
   constexpr const char *l7_output = __builtin_unique_stable_name(l7); // #USN_l7
   // expected-error@#kernelSingleTask{{kernel instantiation changes the result of an evaluated '__builtin_unique_stable_name'}}
   // expected-note@#USN_l7{{'__builtin_unique_stable_name' evaluated here}}
-  // expected-note@#kernel7call{{in instantiation of function template specialization}}
-  kernel_single_task<class kernel7>(l8); // #kernel7call
+  // expected-note@+1{{in instantiation of function template specialization}}
+  kernel_single_task<class kernel7>(l8);
 
   // kernel8 and kernel9 - expect error
-  // Make two lambdas
-  // Call the builtin on the second of the two lambdas (in a constexpr context)
-  // Within a constexpr if, pass the first lambda to a kernel in the true branch,
-  // pass the second lambda to a kernel in the false branch
-  // Test that passing a lambda to the unique stable name builtin and passing it
+  // Tests that passing a lambda to the unique stable name builtin and passing it
   // to a kernel called with an if constexpr branch causes a diagnostic on the
-  // kernel9 use due to the change in the results to the stable name
+  // kernel9 use due to the change in the results to the stable name. This happens
+  // even though the use of kernel9 happens in the false branch of a constexpr if
+  // because both the true and the false branches cause the instantiation of
+  // kernel_single_task.
   auto l9 = []() { return 1; };
   auto l10 = []() { return 2; };
   constexpr const char *l10_output = __builtin_unique_stable_name(l10); // #USN_l10

--- a/clang/tools/libclang/CXCursor.cpp
+++ b/clang/tools/libclang/CXCursor.cpp
@@ -336,11 +336,8 @@ CXCursor cxcursor::MakeCXCursor(const Stmt *S, const Decl *Parent,
   case Stmt::ObjCBoxedExprClass:
   case Stmt::ObjCSubscriptRefExprClass:
   case Stmt::RecoveryExprClass:
-    K = CXCursor_UnexposedExpr;
-    break;
   case Stmt::UniqueStableNameExprClass:
-    // TODO: ERICH: Figureout what a CXCursor is, and how to expose it here.
-    K = CXCursor_NotImplemented;
+    K = CXCursor_UnexposedExpr;
     break;
 
   case Stmt::OpaqueValueExprClass:

--- a/clang/tools/libclang/CXCursor.cpp
+++ b/clang/tools/libclang/CXCursor.cpp
@@ -338,6 +338,10 @@ CXCursor cxcursor::MakeCXCursor(const Stmt *S, const Decl *Parent,
   case Stmt::RecoveryExprClass:
     K = CXCursor_UnexposedExpr;
     break;
+  case Stmt::UniqueStableNameExprClass:
+    // TODO: ERICH: Figureout what a CXCursor is, and how to expose it here.
+    K = CXCursor_NotImplemented;
+    break;
 
   case Stmt::OpaqueValueExprClass:
     if (Expr *Src = cast<OpaqueValueExpr>(S)->getSourceExpr())


### PR DESCRIPTION
Just a WIP to keep you guys up to date on my progress.

As of the initial upload, this does the work to the instantiate-attr that needs to be done in order to have a place to mark all of the lambda types. Additionally, it adds the Expr for the builtin-unique-stable-name that we'll need. The CodeGen part doesn't work, and I've not started messing with the mangler yet, but I intend to do that soon.

Don't worry about review, but if you have a 'todo' that you understand better than me, or spot some obvious error, feel free to share!

@aaronballman, @schittir Not sure why it won't let me add you as a 'reviewer', but here it is.